### PR TITLE
Avoid server crash from ReactGA initialization

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,21 @@
 import '../styles/globals.css'
+import { useEffect } from 'react';
 import ReactGA from 'react-ga';
+
 const TRACKING_ID = "UA-48759266-1"; // OUR_TRACKING_ID
-ReactGA.initialize(TRACKING_ID);
-ReactGA.pageview("/");
 
 function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    // ReactGA depends on the browser `window` object which does not exist on
+    // the server. Wrapping the initialization in `useEffect` ensures it only
+    // runs client-side after the component mounts and avoids "window is not
+    // defined" errors during server-side rendering.
+    if (typeof window !== 'undefined') {
+      ReactGA.initialize(TRACKING_ID);
+      ReactGA.pageview(window.location.pathname + window.location.search);
+    }
+  }, []);
+
   return <Component {...pageProps} />
 }
 


### PR DESCRIPTION
## Summary
- Initialize Google Analytics in a `useEffect` hook so it runs only in the browser
- Log page views using the current path to avoid server-side `window` reference errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895490090008328aa65030eed58acbb