### PR TITLE
Add fade-in animation for joke text

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -89,10 +89,10 @@ class OpenAIData extends React.Component {
         {/* Update the header to be a bit more playful */}
         <h2 className={styles.jokeHeader}>Dad Joke of the Day (Guaranteed to Make You Groan)</h2>
         {question && (
-          <p className={styles.question}>{question}</p>
+          <p key={question} className={`${styles.question} ${styles.fadeIn}`}>{question}</p>
         )}
         {answer && (
-          <p className={styles.answer}>{answer}</p>
+          <p key={answer} className={`${styles.answer} ${styles.fadeIn}`}>{answer}</p>
         )}
       </div>
     );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -201,3 +201,18 @@
 .answer {
   margin-top: 0.5rem;
 }
+
+/* Simple fade-in utility for question and answer text */
+.fadeIn {
+  opacity: 0;
+  animation: fadeIn 0.5s ease-in forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable fade-in animation utility
- apply fade-in to displayed question and answer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68954b8bebd88328a13dba09d0de8f13