### PR TITLE
Add reusable spinner component for loading state

### DIFF
--- a/components/Spinner.js
+++ b/components/Spinner.js
@@ -1,0 +1,18 @@
+import styles from '../styles/Spinner.module.css';
+
+export default function Spinner() {
+  return (
+    <div className={styles.spinnerContainer} role="status" aria-label="Loading">
+      <svg className={styles.spinner} viewBox="0 0 50 50">
+        <circle
+          className={styles.path}
+          cx="25"
+          cy="25"
+          r="20"
+          fill="none"
+          strokeWidth="5"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import React from 'react'
 import styles from '../styles/Home.module.css'
+import Spinner from '../components/Spinner'
 
 
 class OpenAIData extends React.Component {
@@ -78,11 +79,7 @@ class OpenAIData extends React.Component {
       return <div>Error Loading: {error.message}</div>;
     }
     if (!isLoaded) {
-      return (
-        <div className={styles.loadingContainer}>
-          <div className={styles.loadingBox}>Loading...</div>
-        </div>
-      );
+      return <Spinner />;
     }
     return (
       <div className={styles.jokeContainer}>

--- a/styles/Spinner.module.css
+++ b/styles/Spinner.module.css
@@ -1,0 +1,40 @@
+.spinnerContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: 50vh;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  animation: rotate 1s linear infinite;
+}
+
+.path {
+  stroke: #5652bf;
+  stroke-linecap: round;
+  animation: dash 1.5s ease-in-out infinite;
+}
+
+@keyframes rotate {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes dash {
+  0% {
+    stroke-dasharray: 1, 150;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 90, 150;
+    stroke-dashoffset: -35;
+  }
+  100% {
+    stroke-dasharray: 90, 150;
+    stroke-dashoffset: -124;
+  }
+}


### PR DESCRIPTION
## Summary
- create Spinner component with animated SVG and CSS module
- show Spinner in `pages/index.js` until SSE data loads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68954b8931f48328917add0bd344438d