### PR TITLE
feat: theme variables and typography refresh

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import '../styles/globals.css'
 import { useEffect } from 'react';
+import Head from 'next/head';
 import ReactGA from 'react-ga';
 
 const TRACKING_ID = "UA-48759266-1"; // OUR_TRACKING_ID
@@ -16,7 +17,19 @@ function MyApp({ Component, pageProps }) {
     }
   }, []);
 
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  )
 }
 
 export default MyApp

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -17,7 +17,7 @@
   display: flex;
   flex: 1;
   padding: 2rem 0;
-  border-top: 1px solid #eaeaea;
+  border-top: 1px solid var(--color-border);
   justify-content: center;
   align-items: center;
 }
@@ -30,7 +30,7 @@
 }
 
 .title a {
-  color: #0070f3;
+  color: var(--color-primary);
   text-decoration: none;
 }
 
@@ -54,9 +54,9 @@
 }
 
 .code {
-  background: #fafafa;
+  background: var(--color-surface);
   border-radius: 5px;
-  padding: 0.75rem;
+  padding: 1rem;
   font-size: 1.1rem;
   font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
     Bitstream Vera Sans Mono, Courier New, monospace;
@@ -76,7 +76,7 @@
   text-align: left;
   color: inherit;
   text-decoration: none;
-  border: 1px solid #eaeaea;
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
   max-width: 300px;
@@ -85,8 +85,8 @@
 .card:hover,
 .card:focus,
 .card:active {
-  color: #0070f3;
-  border-color: #0070f3;
+  color: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 .card h2 {
@@ -116,10 +116,10 @@
 @media (prefers-color-scheme: dark) {
   .card,
   .footer {
-    border-color: #222;
+    border-color: var(--color-border-dark);
   }
   .code {
-    background: #111;
+    background: var(--color-surface-dark);
   }
   .logo img {
     filter: invert(1);
@@ -129,13 +129,13 @@
 .textbox {
   width: 250px;
   height: 50px;
-  margin: 5px;
+  margin: 0.5rem;
 }
 
 .formbutton {
   width: 120px;
   height: 50px;
-  margin: 5px;
+  margin: 0.5rem;
 }
 
 /* Custom styles for displaying dad jokes clearly */
@@ -148,11 +148,11 @@
   margin-right: auto;
   line-height: 1.6;
   font-size: 1.25rem;
-  background-color: #f9f9f9;
+  background-color: var(--color-surface);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   /* Use a black text color for maximum readability against the light background */
-  color: #000;
+  color: var(--color-text-dark);
 }
 
 .jokeHeader {
@@ -160,7 +160,7 @@
   margin-bottom: 1rem;
   text-align: left;
   /* Use a dark text color for maximum contrast */
-  color: #000;
+  color: var(--color-text-dark);
   font-weight: 700;
   /* Add a subtle accent underline to make the header pop */
   border-bottom: 3px solid #f39c12;
@@ -183,11 +183,11 @@
   text-align: center;
   line-height: 1.6;
   font-size: 1.5rem;
-  background-color: #f9f9f9;
+  background-color: var(--color-surface);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   /* Make the header black for better contrast and add emphasis */
-  color: #000;
+  color: var(--color-text-dark);
   font-weight: 700;
   border-bottom: 2px solid rgba(0, 0, 0, 0.1);
   padding-bottom: 0.5rem;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,12 +1,36 @@
+/* Define global color and gradient variables for easy theming */
+:root {
+  --color-primary: #0070f3;
+  --color-background: #000000;
+  --color-text: #ffffff;
+  --color-text-dark: #000000;
+  --color-surface: #f9f9f9;
+  --color-border: #eaeaea;
+  --color-border-dark: #222222;
+  --color-surface-dark: #111111;
+  --gradient-background: linear-gradient(180deg, #000000 0%, #111111 100%);
+}
+
 html,
 body {
   color-scheme: dark;
-  color: white;
-  background: black;
+  color: var(--color-text);
+  background-color: var(--color-background);
+  background-image: var(--gradient-background);
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
 }
 
 a {
@@ -23,8 +47,9 @@ a {
     color-scheme: dark;
   }
   body {
-    color: white;
-    background: black;
+    color: var(--color-text);
+    background-color: var(--color-background);
+    background-image: var(--gradient-background);
   }
 }
 


### PR DESCRIPTION
## Summary
- introduce CSS variables for color scheme and gradient, and apply Inter font globally
- adopt color variables and rem-based spacing across home styles
- load Google Inter font with Next.js Head for modern typography

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68954b8718988328b75fe804163f5406