### PR TITLE
Restore Speak navigation and restyle Speak page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -99,7 +99,8 @@ class OpenAIData extends React.Component {
 
 export default function Home() {
   const navLinks = [
-    { href: '/', label: 'Home' }
+    { href: '/', label: 'Home' },
+    { href: '/speak', label: 'Speak' }
   ];
   return (
     <div className={styles.container}>

--- a/pages/speak.js
+++ b/pages/speak.js
@@ -3,7 +3,7 @@ import ReactAudioPlayer from 'react-audio-player';
 import { useState } from 'react';
 import Header from '../components/Header'
 import Spinner from '../components/Spinner'
-import styles from '../styles/Home.module.css'
+import styles from '../styles/Speak.module.css'
 
 export default function SpeechHelper() {
 
@@ -13,7 +13,8 @@ export default function SpeechHelper() {
   const [isLoaded, setIsLoadedValue] = useState(false);
 
   const navLinks = [
-    { href: '/', label: 'Home' }
+    { href: '/', label: 'Home' },
+    { href: '/speak', label: 'Speak' }
   ];
 
   const handleInputChange = (event) => {
@@ -66,7 +67,7 @@ export default function SpeechHelper() {
           type="text"
           value={inputValue}
           onChange={handleInputChange}
-          placeholder="Enter What you want to say."
+          placeholder="Enter what you want to say."
         />
         <div className={styles.buttonGroup}>
           <button className={styles.formbutton} onClick={clearText}>Clear</button>
@@ -74,6 +75,7 @@ export default function SpeechHelper() {
         </div>
         {isLoaded && (
           <ReactAudioPlayer
+            className={styles.audioPlayer}
             src={source}
             controls
           />

--- a/styles/Speak.module.css
+++ b/styles/Speak.module.css
@@ -1,0 +1,66 @@
+.container {
+  padding: 0 2rem;
+}
+
+.main {
+  min-height: 100vh;
+  padding: 4rem 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.textbox {
+  width: 100%;
+  max-width: 400px;
+  height: 50px;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  background-color: var(--color-surface-dark);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-dark);
+  border-radius: 4px;
+}
+
+.buttonGroup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+
+.formbutton {
+  width: 100%;
+  max-width: 160px;
+  height: 50px;
+  margin: 0.5rem;
+  background-color: var(--color-primary);
+  color: var(--color-text);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.audioPlayer {
+  margin-top: 1rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+@media (max-width: 600px) {
+  .buttonGroup {
+    flex-direction: column;
+    width: 100%;
+  }
+  .formbutton {
+    max-width: none;
+    width: 100%;
+  }
+  .textbox {
+    max-width: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Add Speak link to header navigation on Home and Speak pages
- Introduce dedicated dark-themed Speak page styles for better responsiveness and button alignment
- Apply new styling and audio player layout on Speak page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895559419708328b166b13439adf638