### PR TITLE
feat: add dad joke dataset and random loader

### DIFF
--- a/data/dad_jokes.txt
+++ b/data/dad_jokes.txt
@@ -1,0 +1,2999 @@
+Question: Why did the Alien from Mars cross the road?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the jolly jaguar plant a garden?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the singing river juggle bananas?
+Answer: to make history giggle.
+
+Question: Why did the Abraham Lincoln start a podcast?
+Answer: because the coffee was too weak.
+
+Question: Why did the Margaret Thatcher start a podcast?
+Answer: because the coffee was too weak.
+
+Question: Why did the Alien from Mars juggle bananas?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the rolling prairie plant a garden?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Margaret Thatcher bake a cake?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Big Ben join a comedy club?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the UFO Pilot plant a garden?
+Answer: to escape the punchline police.
+
+Question: Why did the Golden Gate Bridge host a party?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Angela Merkel join a comedy club?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Mahatma Gandhi plant a garden?
+Answer: because the moon dared it.
+
+Question: Why did the Queen Elizabeth II cross the road?
+Answer: because someone bet it a nickel.
+
+Question: Why did the hand sanitizer bake a cake?
+Answer: because it had nothing better to do.
+
+Question: Why did the Joe Biden juggle bananas?
+Answer: for the sake of comedic timing.
+
+Question: Why did the bathroom mirror start a podcast?
+Answer: because the coffee was too weak.
+
+Question: Why did the plunger go to space?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Kim Jong-un learn to dance?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Statue of Liberty practice yoga?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the zany zebra write a memoir?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the stormy cloud cook spaghetti?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the lazy dog buy a jetpack?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Golden Gate Bridge go to space?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the glowing sunset take up knitting?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the wild weasel host a party?
+Answer: because it had nothing better to do.
+
+Question: Why did the Cosmic Lizard take up knitting?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Mahatma Gandhi write a memoir?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Big Ben plant a garden?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the lazy dog train for a marathon?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Cosmic Lizard start a podcast?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the rolling prairie play the banjo?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Angela Merkel visit the library?
+Answer: to impress the grandchildren.
+
+Question: Why did the Angela Merkel join a comedy club?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Martian Tourist play the banjo?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the cheeky chicken paint a masterpiece?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Queen Elizabeth II practice yoga?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Golden Gate Bridge start a podcast?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the polar ice cap join a comedy club?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the playful panda go to space?
+Answer: because potty humor is timeless.
+
+Question: Why did the tiny turtle bake a cake?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the playful panda buy a jetpack?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the funky flamingo bake a cake?
+Answer: because someone bet it a nickel.
+
+Question: Why did the glowing sunset plant a garden?
+Answer: because the moon dared it.
+
+Question: Why did the tiny turtle practice yoga?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the daring dolphin juggle bananas?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the wild weasel visit the library?
+Answer: to escape the punchline police.
+
+Question: Why did the Cosmic Lizard buy a jetpack?
+Answer: because someone bet it a nickel.
+
+Question: Why did the diaper go to space?
+Answer: to impress the grandchildren.
+
+Question: Why did the hand sanitizer take up knitting?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Margaret Thatcher practice yoga?
+Answer: to impress the grandchildren.
+
+Question: Why did the brave bear go to space?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the ancient oak tree take up knitting?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the dancing waterfall cross the road?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Alien from Mars write a memoir?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the toilet join a comedy club?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the laughing llama join a comedy club?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Eiffel Tower take up knitting?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Stonehenge practice yoga?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the funky flamingo open a cafe?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Angela Merkel go to space?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Mahatma Gandhi juggle bananas?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the curious cat take up knitting?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Napoleon Bonaparte practice yoga?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Mahatma Gandhi join a comedy club?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the mighty moose cross the road?
+Answer: because potty humor is timeless.
+
+Question: Why did the Barack Obama go to space?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the stormy cloud practice yoga?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the tiny turtle study philosophy?
+Answer: because it had nothing better to do.
+
+Question: Why did the polar ice cap go to space?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the hand sanitizer study philosophy?
+Answer: to make history giggle.
+
+Question: Why did the Kim Jong-un host a party?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Great Wall of China cross the road?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Eiffel Tower buy a jetpack?
+Answer: to escape the punchline police.
+
+Question: Why did the Genghis Khan study philosophy?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Great Wall of China buy a jetpack?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the UFO Pilot learn to dance?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the singing river host a party?
+Answer: for the sake of comedic timing.
+
+Question: Why did the sneaky raccoon juggle bananas?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Winston Churchill practice yoga?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Great Wall of China play the banjo?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Nelson Mandela cross the road?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Winston Churchill start a podcast?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the desert cactus cross the road?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Statue of Liberty go to space?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the playful panda play the banjo?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Vladimir Putin learn to dance?
+Answer: to impress the grandchildren.
+
+Question: Why did the toilet paper roll bake a cake?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the rubber duck bake a cake?
+Answer: to make history giggle.
+
+Question: Why did the Winston Churchill take up knitting?
+Answer: because potty humor is timeless.
+
+Question: Why did the Statue of Liberty juggle bananas?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the diaper practice yoga?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the wild weasel plant a garden?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Alien from Mars paint a masterpiece?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the happy hamster juggle bananas?
+Answer: to impress the grandchildren.
+
+Question: Why did the toilet bake a cake?
+Answer: to impress the grandchildren.
+
+Question: Why did the toilet paper roll buy a jetpack?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Taj Mahal practice yoga?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the polar ice cap bake a cake?
+Answer: because potty humor is timeless.
+
+Question: Why did the Eiffel Tower go to space?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Martian Tourist take up knitting?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Xi Jinping bake a cake?
+Answer: because the coffee was too weak.
+
+Question: Why did the singing river host a party?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the E.T. open a cafe?
+Answer: to impress the grandchildren.
+
+Question: Why did the whispering willow play the banjo?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the sneaky raccoon open a cafe?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Alexander the Great paint a masterpiece?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the funky flamingo juggle bananas?
+Answer: to impress the grandchildren.
+
+Question: Why did the George Washington cook spaghetti?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Nelson Mandela open a cafe?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Vladimir Putin play the banjo?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Cleopatra open a cafe?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the singing river join a comedy club?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Genghis Khan visit the library?
+Answer: because the moon dared it.
+
+Question: Why did the majestic mountain cook spaghetti?
+Answer: because the coffee was too weak.
+
+Question: Why did the Statue of Liberty write a memoir?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the soap dispenser learn to dance?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Area 51 Visitor buy a jetpack?
+Answer: to escape the punchline police.
+
+Question: Why did the majestic mountain plant a garden?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Angela Merkel go to space?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Pyramids of Giza play the banjo?
+Answer: because someone bet it a nickel.
+
+Question: Why did the sleepy sloth go to space?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Mount Rushmore write a memoir?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the lazy dog cross the road?
+Answer: because the coffee was too weak.
+
+Question: Why did the brave bear start a podcast?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the witty wolf open a cafe?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the hand sanitizer learn to dance?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Galaxy Hitchhiker take up knitting?
+Answer: because the coffee was too weak.
+
+Question: Why did the bathroom scale study philosophy?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Little Green Man plant a garden?
+Answer: because it had nothing better to do.
+
+Question: Why did the majestic mountain cook spaghetti?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Extraterrestrial Neighbor visit the library?
+Answer: to make history giggle.
+
+Question: Why did the Napoleon Bonaparte buy a jetpack?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the bathroom mirror cross the road?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the desert cactus bake a cake?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Extraterrestrial Neighbor paint a masterpiece?
+Answer: because potty humor is timeless.
+
+Question: Why did the Mahatma Gandhi visit the library?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the bathroom mirror learn to dance?
+Answer: because the moon dared it.
+
+Question: Why did the funky flamingo train for a marathon?
+Answer: because the moon dared it.
+
+Question: Why did the happy hamster play the banjo?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the rubber duck go to space?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the dancing waterfall play the banjo?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the cheeky chicken host a party?
+Answer: to escape the punchline police.
+
+Question: Why did the witty wolf go to space?
+Answer: because the coffee was too weak.
+
+Question: Why did the Area 51 Visitor start a podcast?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the E.T. learn to dance?
+Answer: for the sake of comedic timing.
+
+Question: Why did the UFO Pilot juggle bananas?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Joe Biden write a memoir?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Vladimir Putin bake a cake?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the brave bear juggle bananas?
+Answer: because it had nothing better to do.
+
+Question: Why did the Mount Rushmore study philosophy?
+Answer: because it had nothing better to do.
+
+Question: Why did the Space Invader join a comedy club?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Golden Gate Bridge buy a jetpack?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Napoleon Bonaparte host a party?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the desert cactus take up knitting?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the plunger write a memoir?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the funky flamingo cross the road?
+Answer: because the coffee was too weak.
+
+Question: Why did the Donald Trump visit the library?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the brave bear write a memoir?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the sneaky raccoon study philosophy?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Eiffel Tower buy a jetpack?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the mighty moose learn to dance?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Big Ben go to space?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Kim Jong-un juggle bananas?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Genghis Khan practice yoga?
+Answer: to escape the punchline police.
+
+Question: Why did the Area 51 Visitor start a podcast?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Great Wall of China play the banjo?
+Answer: because the moon dared it.
+
+Question: Why did the Margaret Thatcher cross the road?
+Answer: to escape the punchline police.
+
+Question: Why did the Queen Elizabeth II take up knitting?
+Answer: because potty humor is timeless.
+
+Question: Why did the Statue of Liberty visit the library?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Taj Mahal visit the library?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the plunger buy a jetpack?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Cleopatra buy a jetpack?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Kim Jong-un cook spaghetti?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the whispering willow take up knitting?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the mighty moose paint a masterpiece?
+Answer: because potty humor is timeless.
+
+Question: Why did the glowing sunset play the banjo?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Margaret Thatcher buy a jetpack?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the plunger cook spaghetti?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Cosmic Lizard practice yoga?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the mighty moose host a party?
+Answer: because the coffee was too weak.
+
+Question: Why did the bathroom mirror buy a jetpack?
+Answer: because potty humor is timeless.
+
+Question: Why did the UFO Pilot train for a marathon?
+Answer: because the moon dared it.
+
+Question: Why did the Cleopatra study philosophy?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Nelson Mandela write a memoir?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the rubber duck bake a cake?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the polar ice cap open a cafe?
+Answer: because the moon dared it.
+
+Question: Why did the toilet paper roll visit the library?
+Answer: because someone bet it a nickel.
+
+Question: Why did the dancing waterfall take up knitting?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the bathroom mirror host a party?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the toilet paper roll learn to dance?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Xi Jinping visit the library?
+Answer: because the moon dared it.
+
+Question: Why did the lazy dog play the banjo?
+Answer: because potty humor is timeless.
+
+Question: Why did the Galaxy Hitchhiker host a party?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the brave bear open a cafe?
+Answer: to escape the punchline police.
+
+Question: Why did the Golden Gate Bridge go to space?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Justin Trudeau juggle bananas?
+Answer: because it had nothing better to do.
+
+Question: Why did the Julius Caesar paint a masterpiece?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the sleepy sloth study philosophy?
+Answer: to escape the punchline police.
+
+Question: Why did the Mona Lisa learn to dance?
+Answer: to make history giggle.
+
+Question: Why did the UFO Pilot bake a cake?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Joe Biden juggle bananas?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Kim Jong-un start a podcast?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Martian Tourist cross the road?
+Answer: to impress the grandchildren.
+
+Question: Why did the wild weasel practice yoga?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Golden Gate Bridge buy a jetpack?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the daring dolphin train for a marathon?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Cosmic Lizard open a cafe?
+Answer: to make history giggle.
+
+Question: Why did the Kim Jong-un play the banjo?
+Answer: because it had nothing better to do.
+
+Question: Why did the Joe Biden play the banjo?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Vladimir Putin plant a garden?
+Answer: because potty humor is timeless.
+
+Question: Why did the air freshener train for a marathon?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the bashful bunny host a party?
+Answer: because the moon dared it.
+
+Question: Why did the jolly jaguar buy a jetpack?
+Answer: to escape the punchline police.
+
+Question: Why did the cheeky chicken learn to dance?
+Answer: to escape the punchline police.
+
+Question: Why did the laughing llama take up knitting?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the toilet paper roll cross the road?
+Answer: because the moon dared it.
+
+Question: Why did the whispering willow study philosophy?
+Answer: because potty humor is timeless.
+
+Question: Why did the toilet paint a masterpiece?
+Answer: for the sake of comedic timing.
+
+Question: Why did the ancient oak tree practice yoga?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the bathroom scale join a comedy club?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the sleepy sloth cross the road?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Vladimir Putin cook spaghetti?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the daring dolphin go to space?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Statue of Liberty go to space?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Extraterrestrial Neighbor bake a cake?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Kim Jong-un visit the library?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Abraham Lincoln start a podcast?
+Answer: because the moon dared it.
+
+Question: Why did the Little Green Man join a comedy club?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the bathroom scale visit the library?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the George Washington learn to dance?
+Answer: to escape the punchline police.
+
+Question: Why did the glowing sunset buy a jetpack?
+Answer: to escape the punchline police.
+
+Question: Why did the Eiffel Tower cross the road?
+Answer: for the sake of comedic timing.
+
+Question: Why did the majestic mountain train for a marathon?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Eiffel Tower train for a marathon?
+Answer: for the sake of comedic timing.
+
+Question: Why did the glowing sunset write a memoir?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the spunky spider go to space?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the rubber duck buy a jetpack?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the sneaky raccoon go to space?
+Answer: because potty humor is timeless.
+
+Question: Why did the Donald Trump cross the road?
+Answer: because the coffee was too weak.
+
+Question: Why did the tiny turtle open a cafe?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the rolling prairie paint a masterpiece?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the mighty moose plant a garden?
+Answer: because someone bet it a nickel.
+
+Question: Why did the hand sanitizer take up knitting?
+Answer: to impress the grandchildren.
+
+Question: Why did the playful panda train for a marathon?
+Answer: for the sake of comedic timing.
+
+Question: Why did the happy hamster visit the library?
+Answer: because someone bet it a nickel.
+
+Question: Why did the soap dispenser bake a cake?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Mona Lisa take up knitting?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the toilet paper roll buy a jetpack?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Space Invader learn to dance?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the E.T. learn to dance?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Area 51 Visitor plant a garden?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Kim Jong-un practice yoga?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Space Invader go to space?
+Answer: because the moon dared it.
+
+Question: Why did the George Washington buy a jetpack?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Extraterrestrial Neighbor visit the library?
+Answer: to escape the punchline police.
+
+Question: Why did the bathroom scale learn to dance?
+Answer: because it had nothing better to do.
+
+Question: Why did the Martian Tourist visit the library?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Great Wall of China visit the library?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Queen Elizabeth II bake a cake?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Margaret Thatcher buy a jetpack?
+Answer: because it had nothing better to do.
+
+Question: Why did the Kim Jong-un study philosophy?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Area 51 Visitor go to space?
+Answer: because the coffee was too weak.
+
+Question: Why did the toilet write a memoir?
+Answer: to impress the grandchildren.
+
+Question: Why did the Stonehenge cook spaghetti?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Eiffel Tower learn to dance?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the majestic mountain start a podcast?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Galaxy Hitchhiker write a memoir?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Abraham Lincoln take up knitting?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the ancient oak tree go to space?
+Answer: because the moon dared it.
+
+Question: Why did the Margaret Thatcher cross the road?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Julius Caesar open a cafe?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Napoleon Bonaparte train for a marathon?
+Answer: to escape the punchline police.
+
+Question: Why did the stormy cloud buy a jetpack?
+Answer: because it had nothing better to do.
+
+Question: Why did the Eiffel Tower go to space?
+Answer: because potty humor is timeless.
+
+Question: Why did the Julius Caesar bake a cake?
+Answer: to escape the punchline police.
+
+Question: Why did the Donald Trump juggle bananas?
+Answer: to make history giggle.
+
+Question: Why did the rubber duck buy a jetpack?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Space Invader visit the library?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the wild weasel juggle bananas?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the grumpy goat cross the road?
+Answer: to impress the grandchildren.
+
+Question: Why did the grumpy goat practice yoga?
+Answer: because the moon dared it.
+
+Question: Why did the bathroom scale juggle bananas?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the laughing llama paint a masterpiece?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Joe Biden open a cafe?
+Answer: to make history giggle.
+
+Question: Why did the Nelson Mandela host a party?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Great Wall of China plant a garden?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Pyramids of Giza host a party?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Xi Jinping study philosophy?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the UFO Pilot play the banjo?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Xi Jinping buy a jetpack?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Justin Trudeau write a memoir?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Cleopatra learn to dance?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the glowing sunset plant a garden?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Vladimir Putin cook spaghetti?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the bashful bunny juggle bananas?
+Answer: to escape the punchline police.
+
+Question: Why did the grumpy goat cross the road?
+Answer: because potty humor is timeless.
+
+Question: Why did the Vladimir Putin bake a cake?
+Answer: to escape the punchline police.
+
+Question: Why did the Justin Trudeau play the banjo?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Statue of Liberty plant a garden?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the glowing sunset juggle bananas?
+Answer: because someone bet it a nickel.
+
+Question: Why did the stormy cloud juggle bananas?
+Answer: because potty humor is timeless.
+
+Question: Why did the sleepy sloth join a comedy club?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the majestic mountain study philosophy?
+Answer: to impress the grandchildren.
+
+Question: Why did the spunky spider open a cafe?
+Answer: to make history giggle.
+
+Question: Why did the Mona Lisa join a comedy club?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the brave bear start a podcast?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Great Wall of China train for a marathon?
+Answer: to escape the punchline police.
+
+Question: Why did the Galaxy Hitchhiker play the banjo?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Pyramids of Giza buy a jetpack?
+Answer: to escape the punchline police.
+
+Question: Why did the Eiffel Tower join a comedy club?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Queen Elizabeth II juggle bananas?
+Answer: to make history giggle.
+
+Question: Why did the toilet paper roll cross the road?
+Answer: because the coffee was too weak.
+
+Question: Why did the Area 51 Visitor buy a jetpack?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Vladimir Putin host a party?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the wild weasel join a comedy club?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Abraham Lincoln cook spaghetti?
+Answer: because it had nothing better to do.
+
+Question: Why did the playful panda study philosophy?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the toilet start a podcast?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Donald Trump juggle bananas?
+Answer: to escape the punchline police.
+
+Question: Why did the ancient oak tree visit the library?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Statue of Liberty learn to dance?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Martian Tourist visit the library?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Julius Caesar join a comedy club?
+Answer: because it had nothing better to do.
+
+Question: Why did the UFO Pilot juggle bananas?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the rolling prairie plant a garden?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the cheeky chicken host a party?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Mona Lisa buy a jetpack?
+Answer: because potty humor is timeless.
+
+Question: Why did the curious cat buy a jetpack?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Extraterrestrial Neighbor start a podcast?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the grumpy goat visit the library?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the sneaky raccoon practice yoga?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the rolling prairie practice yoga?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Great Wall of China cook spaghetti?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the air freshener bake a cake?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the soap dispenser take up knitting?
+Answer: for the sake of comedic timing.
+
+Question: Why did the diaper practice yoga?
+Answer: because the coffee was too weak.
+
+Question: Why did the E.T. study philosophy?
+Answer: to impress the grandchildren.
+
+Question: Why did the dancing waterfall plant a garden?
+Answer: to make history giggle.
+
+Question: Why did the Nelson Mandela cross the road?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the lazy dog play the banjo?
+Answer: because potty humor is timeless.
+
+Question: Why did the sneaky raccoon learn to dance?
+Answer: to escape the punchline police.
+
+Question: Why did the Galaxy Hitchhiker practice yoga?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the stormy cloud join a comedy club?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Margaret Thatcher host a party?
+Answer: because the coffee was too weak.
+
+Question: Why did the Queen Elizabeth II start a podcast?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Napoleon Bonaparte visit the library?
+Answer: to escape the punchline police.
+
+Question: Why did the stormy cloud study philosophy?
+Answer: because the moon dared it.
+
+Question: Why did the Donald Trump host a party?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Cosmic Lizard plant a garden?
+Answer: to make history giggle.
+
+Question: Why did the air freshener host a party?
+Answer: to escape the punchline police.
+
+Question: Why did the Taj Mahal train for a marathon?
+Answer: to impress the grandchildren.
+
+Question: Why did the glowing sunset paint a masterpiece?
+Answer: because it had nothing better to do.
+
+Question: Why did the Mona Lisa learn to dance?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Alexander the Great open a cafe?
+Answer: because the coffee was too weak.
+
+Question: Why did the Winston Churchill start a podcast?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the rubber duck train for a marathon?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Queen Elizabeth II play the banjo?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Napoleon Bonaparte host a party?
+Answer: because potty humor is timeless.
+
+Question: Why did the cheeky chicken practice yoga?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Angela Merkel plant a garden?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Napoleon Bonaparte open a cafe?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the bathroom mirror join a comedy club?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the jolly jaguar study philosophy?
+Answer: to escape the punchline police.
+
+Question: Why did the hand sanitizer plant a garden?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the whispering willow practice yoga?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the playful panda cross the road?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Alexander the Great write a memoir?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the plunger take up knitting?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the soap dispenser visit the library?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the zany zebra visit the library?
+Answer: to make history giggle.
+
+Question: Why did the jolly jaguar host a party?
+Answer: because someone bet it a nickel.
+
+Question: Why did the sneaky raccoon cross the road?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Kim Jong-un plant a garden?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Mahatma Gandhi juggle bananas?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the bashful bunny juggle bananas?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Extraterrestrial Neighbor juggle bananas?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Mahatma Gandhi cross the road?
+Answer: because potty humor is timeless.
+
+Question: Why did the Space Invader visit the library?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Nelson Mandela write a memoir?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the stormy cloud write a memoir?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the George Washington practice yoga?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Margaret Thatcher learn to dance?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the curious cat go to space?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the rolling prairie join a comedy club?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Angela Merkel join a comedy club?
+Answer: to make history giggle.
+
+Question: Why did the spunky spider juggle bananas?
+Answer: because the moon dared it.
+
+Question: Why did the daring dolphin juggle bananas?
+Answer: because potty humor is timeless.
+
+Question: Why did the Eiffel Tower play the banjo?
+Answer: because the moon dared it.
+
+Question: Why did the Area 51 Visitor learn to dance?
+Answer: to impress the grandchildren.
+
+Question: Why did the witty wolf bake a cake?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Alien from Mars take up knitting?
+Answer: to impress the grandchildren.
+
+Question: Why did the Queen Elizabeth II join a comedy club?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the witty wolf cook spaghetti?
+Answer: because potty humor is timeless.
+
+Question: Why did the Great Wall of China visit the library?
+Answer: because it had nothing better to do.
+
+Question: Why did the Mahatma Gandhi bake a cake?
+Answer: because the moon dared it.
+
+Question: Why did the curious cat cross the road?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Barack Obama buy a jetpack?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Abraham Lincoln practice yoga?
+Answer: because the coffee was too weak.
+
+Question: Why did the air freshener go to space?
+Answer: because potty humor is timeless.
+
+Question: Why did the Little Green Man paint a masterpiece?
+Answer: because potty humor is timeless.
+
+Question: Why did the sneaky raccoon cross the road?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Nelson Mandela take up knitting?
+Answer: because someone bet it a nickel.
+
+Question: Why did the sleepy sloth write a memoir?
+Answer: for the sake of comedic timing.
+
+Question: Why did the ancient oak tree write a memoir?
+Answer: because the coffee was too weak.
+
+Question: Why did the whispering willow start a podcast?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the curious cat cook spaghetti?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Winston Churchill write a memoir?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the UFO Pilot go to space?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the E.T. go to space?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Margaret Thatcher study philosophy?
+Answer: to make history giggle.
+
+Question: Why did the Mount Rushmore start a podcast?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Nelson Mandela open a cafe?
+Answer: because the coffee was too weak.
+
+Question: Why did the zany zebra open a cafe?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Alexander the Great juggle bananas?
+Answer: to escape the punchline police.
+
+Question: Why did the Mona Lisa visit the library?
+Answer: to escape the punchline police.
+
+Question: Why did the Donald Trump study philosophy?
+Answer: for the sake of comedic timing.
+
+Question: Why did the polar ice cap play the banjo?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the toilet paper roll bake a cake?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Mona Lisa open a cafe?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Martian Tourist juggle bananas?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the soap dispenser juggle bananas?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Stonehenge study philosophy?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Mount Rushmore juggle bananas?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the wild weasel practice yoga?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Queen Elizabeth II train for a marathon?
+Answer: because the coffee was too weak.
+
+Question: Why did the bathroom mirror bake a cake?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the happy hamster study philosophy?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the brave bear open a cafe?
+Answer: to make history giggle.
+
+Question: Why did the E.T. start a podcast?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the diaper buy a jetpack?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the toilet paper roll learn to dance?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Kim Jong-un cross the road?
+Answer: because potty humor is timeless.
+
+Question: Why did the Joe Biden host a party?
+Answer: to impress the grandchildren.
+
+Question: Why did the Abraham Lincoln write a memoir?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Mount Rushmore bake a cake?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the polar ice cap plant a garden?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the George Washington open a cafe?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the brave bear plant a garden?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Mahatma Gandhi cross the road?
+Answer: because it had nothing better to do.
+
+Question: Why did the brave bear play the banjo?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Mount Rushmore open a cafe?
+Answer: to escape the punchline police.
+
+Question: Why did the Alexander the Great cross the road?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the curious cat buy a jetpack?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Statue of Liberty cook spaghetti?
+Answer: because the moon dared it.
+
+Question: Why did the playful panda take up knitting?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the zany zebra learn to dance?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Alien from Mars host a party?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Alien from Mars plant a garden?
+Answer: because potty humor is timeless.
+
+Question: Why did the zany zebra practice yoga?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Kim Jong-un study philosophy?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the dancing waterfall visit the library?
+Answer: for the sake of comedic timing.
+
+Question: Why did the brave bear take up knitting?
+Answer: to make history giggle.
+
+Question: Why did the Angela Merkel start a podcast?
+Answer: because potty humor is timeless.
+
+Question: Why did the Mahatma Gandhi cook spaghetti?
+Answer: because the moon dared it.
+
+Question: Why did the singing river bake a cake?
+Answer: because the coffee was too weak.
+
+Question: Why did the Nelson Mandela visit the library?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the spunky spider join a comedy club?
+Answer: to escape the punchline police.
+
+Question: Why did the whispering willow host a party?
+Answer: because potty humor is timeless.
+
+Question: Why did the witty wolf train for a marathon?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the sneaky raccoon buy a jetpack?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the E.T. start a podcast?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Mount Rushmore join a comedy club?
+Answer: to make history giggle.
+
+Question: Why did the bathroom scale open a cafe?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Statue of Liberty juggle bananas?
+Answer: for the sake of comedic timing.
+
+Question: Why did the plunger cook spaghetti?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Mona Lisa learn to dance?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the ancient oak tree study philosophy?
+Answer: because the coffee was too weak.
+
+Question: Why did the Galaxy Hitchhiker buy a jetpack?
+Answer: because potty humor is timeless.
+
+Question: Why did the glowing sunset host a party?
+Answer: because someone bet it a nickel.
+
+Question: Why did the polar ice cap open a cafe?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the rolling prairie go to space?
+Answer: to impress the grandchildren.
+
+Question: Why did the Margaret Thatcher open a cafe?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Mona Lisa study philosophy?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Julius Caesar juggle bananas?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Angela Merkel study philosophy?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the diaper take up knitting?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Mahatma Gandhi practice yoga?
+Answer: because someone bet it a nickel.
+
+Question: Why did the desert cactus train for a marathon?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Mount Rushmore host a party?
+Answer: to make history giggle.
+
+Question: Why did the wild weasel plant a garden?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the witty wolf bake a cake?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the zany zebra buy a jetpack?
+Answer: to impress the grandchildren.
+
+Question: Why did the bathroom mirror start a podcast?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the happy hamster train for a marathon?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Mount Rushmore practice yoga?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Extraterrestrial Neighbor start a podcast?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the toilet paper roll host a party?
+Answer: to impress the grandchildren.
+
+Question: Why did the Justin Trudeau bake a cake?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Stonehenge write a memoir?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Winston Churchill write a memoir?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the polar ice cap learn to dance?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the bathroom mirror paint a masterpiece?
+Answer: because the coffee was too weak.
+
+Question: Why did the Alien from Mars take up knitting?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the tiny turtle open a cafe?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the dancing waterfall host a party?
+Answer: because the moon dared it.
+
+Question: Why did the hand sanitizer host a party?
+Answer: to make history giggle.
+
+Question: Why did the Donald Trump practice yoga?
+Answer: because the coffee was too weak.
+
+Question: Why did the dancing waterfall paint a masterpiece?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Statue of Liberty write a memoir?
+Answer: because the coffee was too weak.
+
+Question: Why did the toilet paper roll bake a cake?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Winston Churchill cross the road?
+Answer: to impress the grandchildren.
+
+Question: Why did the soap dispenser practice yoga?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the sleepy sloth host a party?
+Answer: to escape the punchline police.
+
+Question: Why did the Xi Jinping bake a cake?
+Answer: because the coffee was too weak.
+
+Question: Why did the Napoleon Bonaparte play the banjo?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the bathroom mirror go to space?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Donald Trump start a podcast?
+Answer: to impress the grandchildren.
+
+Question: Why did the Alien from Mars learn to dance?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the brave bear juggle bananas?
+Answer: because the moon dared it.
+
+Question: Why did the polar ice cap take up knitting?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Little Green Man paint a masterpiece?
+Answer: to impress the grandchildren.
+
+Question: Why did the Abraham Lincoln study philosophy?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the witty wolf paint a masterpiece?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Martian Tourist go to space?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Joe Biden paint a masterpiece?
+Answer: to make history giggle.
+
+Question: Why did the polar ice cap write a memoir?
+Answer: because someone bet it a nickel.
+
+Question: Why did the majestic mountain host a party?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the mighty moose open a cafe?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the witty wolf learn to dance?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Napoleon Bonaparte juggle bananas?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Justin Trudeau train for a marathon?
+Answer: to escape the punchline police.
+
+Question: Why did the Area 51 Visitor practice yoga?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Joe Biden host a party?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the singing river cook spaghetti?
+Answer: because someone bet it a nickel.
+
+Question: Why did the soap dispenser visit the library?
+Answer: because the coffee was too weak.
+
+Question: Why did the cheeky chicken juggle bananas?
+Answer: because the coffee was too weak.
+
+Question: Why did the Space Invader take up knitting?
+Answer: because the moon dared it.
+
+Question: Why did the bathroom scale study philosophy?
+Answer: because potty humor is timeless.
+
+Question: Why did the Napoleon Bonaparte write a memoir?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Genghis Khan buy a jetpack?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Great Wall of China cross the road?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the whispering willow study philosophy?
+Answer: because it had nothing better to do.
+
+Question: Why did the toilet paper roll plant a garden?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the jolly jaguar bake a cake?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Winston Churchill go to space?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the stormy cloud paint a masterpiece?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Napoleon Bonaparte open a cafe?
+Answer: for the sake of comedic timing.
+
+Question: Why did the bashful bunny juggle bananas?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the whispering willow write a memoir?
+Answer: because the coffee was too weak.
+
+Question: Why did the Alien from Mars open a cafe?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Abraham Lincoln study philosophy?
+Answer: because the coffee was too weak.
+
+Question: Why did the Julius Caesar learn to dance?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Mount Rushmore start a podcast?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the soap dispenser host a party?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Alien from Mars open a cafe?
+Answer: because the coffee was too weak.
+
+Question: Why did the Martian Tourist write a memoir?
+Answer: to impress the grandchildren.
+
+Question: Why did the Napoleon Bonaparte play the banjo?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Mona Lisa plant a garden?
+Answer: to make history giggle.
+
+Question: Why did the daring dolphin juggle bananas?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the laughing llama practice yoga?
+Answer: to escape the punchline police.
+
+Question: Why did the Golden Gate Bridge learn to dance?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the toilet paper roll cross the road?
+Answer: to escape the punchline police.
+
+Question: Why did the Great Wall of China cook spaghetti?
+Answer: to escape the punchline police.
+
+Question: Why did the Cleopatra visit the library?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Great Wall of China learn to dance?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the E.T. visit the library?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Angela Merkel buy a jetpack?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the laughing llama go to space?
+Answer: for the sake of comedic timing.
+
+Question: Why did the ancient oak tree play the banjo?
+Answer: to make history giggle.
+
+Question: Why did the rolling prairie paint a masterpiece?
+Answer: because potty humor is timeless.
+
+Question: Why did the Cosmic Lizard train for a marathon?
+Answer: because someone bet it a nickel.
+
+Question: Why did the grumpy goat study philosophy?
+Answer: because potty humor is timeless.
+
+Question: Why did the ancient oak tree go to space?
+Answer: because someone bet it a nickel.
+
+Question: Why did the polar ice cap join a comedy club?
+Answer: because potty humor is timeless.
+
+Question: Why did the toilet paper roll visit the library?
+Answer: because the moon dared it.
+
+Question: Why did the ancient oak tree study philosophy?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the happy hamster visit the library?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Mount Rushmore practice yoga?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Pyramids of Giza practice yoga?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the polar ice cap study philosophy?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Mona Lisa train for a marathon?
+Answer: to impress the grandchildren.
+
+Question: Why did the rubber duck visit the library?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Area 51 Visitor play the banjo?
+Answer: to escape the punchline police.
+
+Question: Why did the Alien from Mars paint a masterpiece?
+Answer: because potty humor is timeless.
+
+Question: Why did the desert cactus train for a marathon?
+Answer: because the moon dared it.
+
+Question: Why did the Eiffel Tower train for a marathon?
+Answer: to make history giggle.
+
+Question: Why did the Martian Tourist play the banjo?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the bashful bunny host a party?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Xi Jinping take up knitting?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Queen Elizabeth II cook spaghetti?
+Answer: for the sake of comedic timing.
+
+Question: Why did the glowing sunset write a memoir?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Xi Jinping visit the library?
+Answer: because the moon dared it.
+
+Question: Why did the E.T. practice yoga?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Napoleon Bonaparte cross the road?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Eiffel Tower buy a jetpack?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the mighty moose go to space?
+Answer: because potty humor is timeless.
+
+Question: Why did the laughing llama open a cafe?
+Answer: because the coffee was too weak.
+
+Question: Why did the Vladimir Putin study philosophy?
+Answer: because the coffee was too weak.
+
+Question: Why did the Julius Caesar go to space?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the mighty moose cook spaghetti?
+Answer: because it had nothing better to do.
+
+Question: Why did the toilet paper roll train for a marathon?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the mighty moose study philosophy?
+Answer: because the coffee was too weak.
+
+Question: Why did the rubber duck train for a marathon?
+Answer: to make history giggle.
+
+Question: Why did the tiny turtle play the banjo?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the wild weasel write a memoir?
+Answer: to escape the punchline police.
+
+Question: Why did the tiny turtle open a cafe?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the singing river play the banjo?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the mighty moose bake a cake?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Eiffel Tower write a memoir?
+Answer: because the coffee was too weak.
+
+Question: Why did the tiny turtle cook spaghetti?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Extraterrestrial Neighbor start a podcast?
+Answer: to make history giggle.
+
+Question: Why did the happy hamster train for a marathon?
+Answer: to make history giggle.
+
+Question: Why did the sleepy sloth cross the road?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Pyramids of Giza train for a marathon?
+Answer: to impress the grandchildren.
+
+Question: Why did the wild weasel take up knitting?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the desert cactus play the banjo?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the wild weasel paint a masterpiece?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Alexander the Great practice yoga?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Big Ben write a memoir?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Statue of Liberty host a party?
+Answer: to escape the punchline police.
+
+Question: Why did the Space Invader practice yoga?
+Answer: because the coffee was too weak.
+
+Question: Why did the Space Invader bake a cake?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the sleepy sloth visit the library?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Winston Churchill plant a garden?
+Answer: to impress the grandchildren.
+
+Question: Why did the Napoleon Bonaparte open a cafe?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Vladimir Putin study philosophy?
+Answer: because the coffee was too weak.
+
+Question: Why did the mighty moose bake a cake?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the mighty moose take up knitting?
+Answer: to make history giggle.
+
+Question: Why did the Joe Biden paint a masterpiece?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Great Wall of China cross the road?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the singing river join a comedy club?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the laughing llama plant a garden?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Little Green Man cross the road?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Angela Merkel go to space?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Space Invader juggle bananas?
+Answer: because it had nothing better to do.
+
+Question: Why did the glowing sunset study philosophy?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Great Wall of China paint a masterpiece?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Martian Tourist paint a masterpiece?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the air freshener plant a garden?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the happy hamster go to space?
+Answer: because potty humor is timeless.
+
+Question: Why did the tiny turtle bake a cake?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Galaxy Hitchhiker learn to dance?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Statue of Liberty go to space?
+Answer: because potty humor is timeless.
+
+Question: Why did the Mount Rushmore go to space?
+Answer: because the moon dared it.
+
+Question: Why did the toilet cross the road?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Golden Gate Bridge study philosophy?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the polar ice cap cross the road?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Xi Jinping cook spaghetti?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the UFO Pilot bake a cake?
+Answer: because potty humor is timeless.
+
+Question: Why did the witty wolf visit the library?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Galaxy Hitchhiker juggle bananas?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the hand sanitizer plant a garden?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Mahatma Gandhi buy a jetpack?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Stonehenge buy a jetpack?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the soap dispenser cross the road?
+Answer: for the sake of comedic timing.
+
+Question: Why did the lazy dog bake a cake?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Vladimir Putin open a cafe?
+Answer: because it had nothing better to do.
+
+Question: Why did the Galaxy Hitchhiker take up knitting?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the E.T. juggle bananas?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the lazy dog plant a garden?
+Answer: because it had nothing better to do.
+
+Question: Why did the Eiffel Tower play the banjo?
+Answer: because potty humor is timeless.
+
+Question: Why did the Statue of Liberty practice yoga?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Taj Mahal bake a cake?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Kim Jong-un cook spaghetti?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the soap dispenser study philosophy?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the stormy cloud play the banjo?
+Answer: to escape the punchline police.
+
+Question: Why did the Xi Jinping buy a jetpack?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the tiny turtle write a memoir?
+Answer: because it had nothing better to do.
+
+Question: Why did the Xi Jinping visit the library?
+Answer: because someone bet it a nickel.
+
+Question: Why did the grumpy goat take up knitting?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Barack Obama cook spaghetti?
+Answer: to make history giggle.
+
+Question: Why did the witty wolf join a comedy club?
+Answer: to make history giggle.
+
+Question: Why did the hand sanitizer learn to dance?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Extraterrestrial Neighbor take up knitting?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Big Ben join a comedy club?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the cheeky chicken host a party?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the UFO Pilot bake a cake?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Nelson Mandela play the banjo?
+Answer: because the moon dared it.
+
+Question: Why did the Nelson Mandela host a party?
+Answer: to escape the punchline police.
+
+Question: Why did the rolling prairie juggle bananas?
+Answer: to escape the punchline police.
+
+Question: Why did the Genghis Khan juggle bananas?
+Answer: to make history giggle.
+
+Question: Why did the Nelson Mandela cook spaghetti?
+Answer: because the coffee was too weak.
+
+Question: Why did the ancient oak tree bake a cake?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Barack Obama cross the road?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Statue of Liberty train for a marathon?
+Answer: because someone bet it a nickel.
+
+Question: Why did the George Washington join a comedy club?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Justin Trudeau go to space?
+Answer: because potty humor is timeless.
+
+Question: Why did the laughing llama write a memoir?
+Answer: because the coffee was too weak.
+
+Question: Why did the diaper go to space?
+Answer: because the moon dared it.
+
+Question: Why did the Little Green Man visit the library?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the desert cactus join a comedy club?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the cheeky chicken start a podcast?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Julius Caesar study philosophy?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the bathroom scale practice yoga?
+Answer: to make history giggle.
+
+Question: Why did the Abraham Lincoln plant a garden?
+Answer: to escape the punchline police.
+
+Question: Why did the Great Wall of China train for a marathon?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Justin Trudeau open a cafe?
+Answer: to escape the punchline police.
+
+Question: Why did the Extraterrestrial Neighbor study philosophy?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the brave bear learn to dance?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Space Invader practice yoga?
+Answer: because it had nothing better to do.
+
+Question: Why did the tiny turtle learn to dance?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the daring dolphin buy a jetpack?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the bathroom mirror practice yoga?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Great Wall of China start a podcast?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the brave bear bake a cake?
+Answer: because it had nothing better to do.
+
+Question: Why did the funky flamingo take up knitting?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the tiny turtle go to space?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Galaxy Hitchhiker paint a masterpiece?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the George Washington learn to dance?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Golden Gate Bridge train for a marathon?
+Answer: because potty humor is timeless.
+
+Question: Why did the Mahatma Gandhi cross the road?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Taj Mahal visit the library?
+Answer: because the coffee was too weak.
+
+Question: Why did the Big Ben learn to dance?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the cheeky chicken start a podcast?
+Answer: because the moon dared it.
+
+Question: Why did the tiny turtle buy a jetpack?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Little Green Man study philosophy?
+Answer: to escape the punchline police.
+
+Question: Why did the Space Invader write a memoir?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the desert cactus paint a masterpiece?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the mighty moose play the banjo?
+Answer: because the coffee was too weak.
+
+Question: Why did the bashful bunny cook spaghetti?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Nelson Mandela take up knitting?
+Answer: because potty humor is timeless.
+
+Question: Why did the UFO Pilot cross the road?
+Answer: to impress the grandchildren.
+
+Question: Why did the mighty moose play the banjo?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the bashful bunny cook spaghetti?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the daring dolphin visit the library?
+Answer: because the coffee was too weak.
+
+Question: Why did the UFO Pilot buy a jetpack?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Abraham Lincoln play the banjo?
+Answer: because the coffee was too weak.
+
+Question: Why did the George Washington start a podcast?
+Answer: because someone bet it a nickel.
+
+Question: Why did the sleepy sloth start a podcast?
+Answer: to make history giggle.
+
+Question: Why did the Nelson Mandela visit the library?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Pyramids of Giza play the banjo?
+Answer: for the sake of comedic timing.
+
+Question: Why did the soap dispenser host a party?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Margaret Thatcher learn to dance?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the funky flamingo plant a garden?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the UFO Pilot go to space?
+Answer: because the coffee was too weak.
+
+Question: Why did the George Washington take up knitting?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the singing river paint a masterpiece?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Vladimir Putin bake a cake?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Julius Caesar practice yoga?
+Answer: for the sake of comedic timing.
+
+Question: Why did the desert cactus play the banjo?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Napoleon Bonaparte start a podcast?
+Answer: because potty humor is timeless.
+
+Question: Why did the Nelson Mandela learn to dance?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the soap dispenser play the banjo?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the brave bear take up knitting?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the daring dolphin buy a jetpack?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the toilet train for a marathon?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Taj Mahal juggle bananas?
+Answer: because it had nothing better to do.
+
+Question: Why did the Alexander the Great train for a marathon?
+Answer: to escape the punchline police.
+
+Question: Why did the Pyramids of Giza train for a marathon?
+Answer: because someone bet it a nickel.
+
+Question: Why did the wild weasel buy a jetpack?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the daring dolphin go to space?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the sleepy sloth bake a cake?
+Answer: because the coffee was too weak.
+
+Question: Why did the Vladimir Putin host a party?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the stormy cloud join a comedy club?
+Answer: because someone bet it a nickel.
+
+Question: Why did the lazy dog juggle bananas?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Great Wall of China host a party?
+Answer: because the coffee was too weak.
+
+Question: Why did the desert cactus buy a jetpack?
+Answer: because potty humor is timeless.
+
+Question: Why did the Joe Biden train for a marathon?
+Answer: because it had nothing better to do.
+
+Question: Why did the mighty moose cook spaghetti?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the diaper practice yoga?
+Answer: to impress the grandchildren.
+
+Question: Why did the hand sanitizer play the banjo?
+Answer: to escape the punchline police.
+
+Question: Why did the Cleopatra train for a marathon?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the E.T. play the banjo?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Abraham Lincoln bake a cake?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the glowing sunset visit the library?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the grumpy goat paint a masterpiece?
+Answer: because the coffee was too weak.
+
+Question: Why did the Justin Trudeau start a podcast?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Barack Obama paint a masterpiece?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the George Washington study philosophy?
+Answer: because potty humor is timeless.
+
+Question: Why did the Eiffel Tower cross the road?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the playful panda play the banjo?
+Answer: because potty humor is timeless.
+
+Question: Why did the Martian Tourist cook spaghetti?
+Answer: because it had nothing better to do.
+
+Question: Why did the hand sanitizer cross the road?
+Answer: because potty humor is timeless.
+
+Question: Why did the Statue of Liberty practice yoga?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Taj Mahal cook spaghetti?
+Answer: because someone bet it a nickel.
+
+Question: Why did the air freshener cook spaghetti?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the polar ice cap bake a cake?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Joe Biden study philosophy?
+Answer: because the coffee was too weak.
+
+Question: Why did the Joe Biden cross the road?
+Answer: because the moon dared it.
+
+Question: Why did the Abraham Lincoln write a memoir?
+Answer: to escape the punchline police.
+
+Question: Why did the lazy dog cross the road?
+Answer: to make history giggle.
+
+Question: Why did the Donald Trump paint a masterpiece?
+Answer: because potty humor is timeless.
+
+Question: Why did the hand sanitizer study philosophy?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Mahatma Gandhi bake a cake?
+Answer: to make history giggle.
+
+Question: Why did the laughing llama learn to dance?
+Answer: because someone bet it a nickel.
+
+Question: Why did the ancient oak tree paint a masterpiece?
+Answer: because it had nothing better to do.
+
+Question: Why did the Nelson Mandela start a podcast?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the dancing waterfall host a party?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Xi Jinping visit the library?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the grumpy goat paint a masterpiece?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Mahatma Gandhi buy a jetpack?
+Answer: to impress the grandchildren.
+
+Question: Why did the Mount Rushmore go to space?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Donald Trump join a comedy club?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the polar ice cap visit the library?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the bathroom mirror play the banjo?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Great Wall of China go to space?
+Answer: because the coffee was too weak.
+
+Question: Why did the plunger train for a marathon?
+Answer: because the coffee was too weak.
+
+Question: Why did the stormy cloud study philosophy?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Space Invader play the banjo?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Pyramids of Giza juggle bananas?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Mount Rushmore study philosophy?
+Answer: for the sake of comedic timing.
+
+Question: Why did the happy hamster go to space?
+Answer: because the coffee was too weak.
+
+Question: Why did the brave bear host a party?
+Answer: because the moon dared it.
+
+Question: Why did the Great Wall of China buy a jetpack?
+Answer: because it had nothing better to do.
+
+Question: Why did the Alexander the Great join a comedy club?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Genghis Khan play the banjo?
+Answer: to impress the grandchildren.
+
+Question: Why did the diaper paint a masterpiece?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the hand sanitizer start a podcast?
+Answer: because the coffee was too weak.
+
+Question: Why did the sleepy sloth juggle bananas?
+Answer: because the moon dared it.
+
+Question: Why did the majestic mountain practice yoga?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the bashful bunny write a memoir?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the funky flamingo play the banjo?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Martian Tourist cross the road?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Stonehenge practice yoga?
+Answer: because potty humor is timeless.
+
+Question: Why did the Donald Trump juggle bananas?
+Answer: to make history giggle.
+
+Question: Why did the Julius Caesar learn to dance?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the mighty moose cook spaghetti?
+Answer: because the coffee was too weak.
+
+Question: Why did the tiny turtle start a podcast?
+Answer: to escape the punchline police.
+
+Question: Why did the Space Invader study philosophy?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Barack Obama write a memoir?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the glowing sunset start a podcast?
+Answer: because the moon dared it.
+
+Question: Why did the dancing waterfall join a comedy club?
+Answer: to impress the grandchildren.
+
+Question: Why did the air freshener cross the road?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Mona Lisa join a comedy club?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Napoleon Bonaparte cook spaghetti?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Genghis Khan host a party?
+Answer: to make history giggle.
+
+Question: Why did the toilet bake a cake?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the polar ice cap go to space?
+Answer: because it had nothing better to do.
+
+Question: Why did the majestic mountain host a party?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Stonehenge buy a jetpack?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the plunger learn to dance?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Martian Tourist train for a marathon?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the playful panda join a comedy club?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the singing river go to space?
+Answer: because the coffee was too weak.
+
+Question: Why did the Queen Elizabeth II start a podcast?
+Answer: because the moon dared it.
+
+Question: Why did the Extraterrestrial Neighbor join a comedy club?
+Answer: because the moon dared it.
+
+Question: Why did the Taj Mahal bake a cake?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the diaper host a party?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Xi Jinping buy a jetpack?
+Answer: because someone bet it a nickel.
+
+Question: Why did the stormy cloud open a cafe?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the spunky spider bake a cake?
+Answer: to make history giggle.
+
+Question: Why did the Abraham Lincoln host a party?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the diaper train for a marathon?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the laughing llama buy a jetpack?
+Answer: to escape the punchline police.
+
+Question: Why did the Donald Trump plant a garden?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Mahatma Gandhi learn to dance?
+Answer: because potty humor is timeless.
+
+Question: Why did the desert cactus go to space?
+Answer: to impress the grandchildren.
+
+Question: Why did the rubber duck paint a masterpiece?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the playful panda study philosophy?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the playful panda host a party?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the bathroom mirror play the banjo?
+Answer: because the coffee was too weak.
+
+Question: Why did the Napoleon Bonaparte plant a garden?
+Answer: because it had nothing better to do.
+
+Question: Why did the UFO Pilot paint a masterpiece?
+Answer: because the coffee was too weak.
+
+Question: Why did the grumpy goat join a comedy club?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Donald Trump buy a jetpack?
+Answer: for the sake of comedic timing.
+
+Question: Why did the bashful bunny write a memoir?
+Answer: because the coffee was too weak.
+
+Question: Why did the Stonehenge cook spaghetti?
+Answer: to escape the punchline police.
+
+Question: Why did the Barack Obama take up knitting?
+Answer: to escape the punchline police.
+
+Question: Why did the Alien from Mars open a cafe?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Galaxy Hitchhiker open a cafe?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the plunger learn to dance?
+Answer: because it had nothing better to do.
+
+Question: Why did the Angela Merkel host a party?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the wild weasel study philosophy?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Extraterrestrial Neighbor take up knitting?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the toilet paper roll open a cafe?
+Answer: because the coffee was too weak.
+
+Question: Why did the Julius Caesar start a podcast?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the whispering willow train for a marathon?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Julius Caesar train for a marathon?
+Answer: because it had nothing better to do.
+
+Question: Why did the ancient oak tree train for a marathon?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the stormy cloud take up knitting?
+Answer: because the moon dared it.
+
+Question: Why did the Genghis Khan juggle bananas?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Space Invader learn to dance?
+Answer: to impress the grandchildren.
+
+Question: Why did the Mahatma Gandhi cook spaghetti?
+Answer: because it had nothing better to do.
+
+Question: Why did the plunger paint a masterpiece?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the plunger paint a masterpiece?
+Answer: to escape the punchline police.
+
+Question: Why did the polar ice cap open a cafe?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Kim Jong-un write a memoir?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the sleepy sloth write a memoir?
+Answer: to impress the grandchildren.
+
+Question: Why did the Kim Jong-un train for a marathon?
+Answer: for the sake of comedic timing.
+
+Question: Why did the toilet host a party?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the desert cactus take up knitting?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Extraterrestrial Neighbor plant a garden?
+Answer: for the sake of comedic timing.
+
+Question: Why did the zany zebra plant a garden?
+Answer: for the sake of comedic timing.
+
+Question: Why did the air freshener juggle bananas?
+Answer: because potty humor is timeless.
+
+Question: Why did the Alien from Mars cross the road?
+Answer: to escape the punchline police.
+
+Question: Why did the wild weasel go to space?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Extraterrestrial Neighbor plant a garden?
+Answer: to impress the grandchildren.
+
+Question: Why did the polar ice cap cross the road?
+Answer: because the moon dared it.
+
+Question: Why did the E.T. take up knitting?
+Answer: because someone bet it a nickel.
+
+Question: Why did the Napoleon Bonaparte bake a cake?
+Answer: to make history giggle.
+
+Question: Why did the rubber duck visit the library?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Abraham Lincoln start a podcast?
+Answer: to escape the punchline police.
+
+Question: Why did the Nelson Mandela bake a cake?
+Answer: to impress the grandchildren.
+
+Question: Why did the Abraham Lincoln take up knitting?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Cosmic Lizard plant a garden?
+Answer: to impress the grandchildren.
+
+Question: Why did the curious cat bake a cake?
+Answer: to impress the grandchildren.
+
+Question: Why did the bathroom mirror buy a jetpack?
+Answer: because potty humor is timeless.
+
+Question: Why did the zany zebra cross the road?
+Answer: to escape the punchline police.
+
+Question: Why did the tiny turtle cross the road?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the polar ice cap practice yoga?
+Answer: to make history giggle.
+
+Question: Why did the laughing llama write a memoir?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the stormy cloud take up knitting?
+Answer: because the moon dared it.
+
+Question: Why did the zany zebra write a memoir?
+Answer: because potty humor is timeless.
+
+Question: Why did the dancing waterfall play the banjo?
+Answer: to make history giggle.
+
+Question: Why did the daring dolphin plant a garden?
+Answer: to make history giggle.
+
+Question: Why did the E.T. host a party?
+Answer: for the sake of comedic timing.
+
+Question: Why did the diaper play the banjo?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the hand sanitizer join a comedy club?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Cosmic Lizard start a podcast?
+Answer: because the moon dared it.
+
+Question: Why did the sneaky raccoon join a comedy club?
+Answer: to escape the punchline police.
+
+Question: Why did the jolly jaguar go to space?
+Answer: because it had nothing better to do.
+
+Question: Why did the cheeky chicken start a podcast?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the brave bear go to space?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the witty wolf train for a marathon?
+Answer: to escape the punchline police.
+
+Question: Why did the happy hamster practice yoga?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Extraterrestrial Neighbor play the banjo?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Area 51 Visitor take up knitting?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Eiffel Tower open a cafe?
+Answer: to escape the punchline police.
+
+Question: Why did the lazy dog cross the road?
+Answer: to escape the punchline police.
+
+Question: Why did the Napoleon Bonaparte cook spaghetti?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the tiny turtle take up knitting?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the bashful bunny practice yoga?
+Answer: to impress the grandchildren.
+
+Question: Why did the lazy dog visit the library?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Mona Lisa practice yoga?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Donald Trump cook spaghetti?
+Answer: to impress the grandchildren.
+
+Question: Why did the bathroom mirror host a party?
+Answer: because the moon dared it.
+
+Question: Why did the desert cactus plant a garden?
+Answer: to impress the grandchildren.
+
+Question: Why did the Space Invader open a cafe?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Big Ben bake a cake?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Stonehenge study philosophy?
+Answer: to make history giggle.
+
+Question: Why did the Extraterrestrial Neighbor juggle bananas?
+Answer: to make history giggle.
+
+Question: Why did the funky flamingo practice yoga?
+Answer: because the coffee was too weak.
+
+Question: Why did the diaper take up knitting?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the whispering willow bake a cake?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the Cosmic Lizard train for a marathon?
+Answer: to escape the punchline police.
+
+Question: Why did the Great Wall of China practice yoga?
+Answer: to impress the grandchildren.
+
+Question: Why did the stormy cloud juggle bananas?
+Answer: to make history giggle.
+
+Question: Why did the polar ice cap learn to dance?
+Answer: to impress the grandchildren.
+
+Question: Why did the rubber duck practice yoga?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Big Ben play the banjo?
+Answer: because potty humor is timeless.
+
+Question: Why did the witty wolf host a party?
+Answer: to impress the grandchildren.
+
+Question: Why did the Winston Churchill play the banjo?
+Answer: because it had nothing better to do.
+
+Question: Why did the Winston Churchill go to space?
+Answer: to make history giggle.
+
+Question: Why did the Queen Elizabeth II juggle bananas?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Angela Merkel train for a marathon?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the toilet juggle bananas?
+Answer: because the moon dared it.
+
+Question: Why did the toilet take up knitting?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Nelson Mandela train for a marathon?
+Answer: to make history giggle.
+
+Question: Why did the brave bear juggle bananas?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Big Ben bake a cake?
+Answer: because the moon dared it.
+
+Question: Why did the brave bear learn to dance?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Big Ben buy a jetpack?
+Answer: to escape the punchline police.
+
+Question: Why did the ancient oak tree write a memoir?
+Answer: because potty humor is timeless.
+
+Question: Why did the Joe Biden open a cafe?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the rubber duck paint a masterpiece?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the Winston Churchill cross the road?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Statue of Liberty plant a garden?
+Answer: for the sake of comedic timing.
+
+Question: Why did the glowing sunset learn to dance?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Abraham Lincoln buy a jetpack?
+Answer: because potty humor is timeless.
+
+Question: Why did the curious cat go to space?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Donald Trump plant a garden?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the majestic mountain play the banjo?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Martian Tourist cross the road?
+Answer: for the sake of comedic timing.
+
+Question: Why did the air freshener cook spaghetti?
+Answer: for the sake of comedic timing.
+
+Question: Why did the Statue of Liberty practice yoga?
+Answer: because someone bet it a nickel.
+
+Question: Why did the funky flamingo open a cafe?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the dancing waterfall learn to dance?
+Answer: because the moon dared it.
+
+Question: Why did the Nelson Mandela buy a jetpack?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the mighty moose host a party?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Barack Obama visit the library?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the wild weasel write a memoir?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the Martian Tourist cook spaghetti?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Mahatma Gandhi open a cafe?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the laughing llama go to space?
+Answer: to make history giggle.
+
+Question: Why did the Pyramids of Giza plant a garden?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Mount Rushmore learn to dance?
+Answer: for the sake of comedic timing.
+
+Question: Why did the funky flamingo take up knitting?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the curious cat open a cafe?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the Nelson Mandela plant a garden?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Space Invader open a cafe?
+Answer: to prove it was a legend in its own time.
+
+Question: Why did the curious cat cross the road?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the desert cactus bake a cake?
+Answer: because the moon dared it.
+
+Question: Why did the daring dolphin visit the library?
+Answer: for the sake of comedic timing.
+
+Question: Why did the sleepy sloth visit the library?
+Answer: to escape the punchline police.
+
+Question: Why did the toilet open a cafe?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Justin Trudeau cook spaghetti?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the Great Wall of China cook spaghetti?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the daring dolphin juggle bananas?
+Answer: because the moon dared it.
+
+Question: Why did the Space Invader cross the road?
+Answer: because the coffee was too weak.
+
+Question: Why did the Napoleon Bonaparte juggle bananas?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the witty wolf visit the library?
+Answer: to escape the punchline police.
+
+Question: Why did the George Washington host a party?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Space Invader train for a marathon?
+Answer: because national treasure status gets boring without humor.
+
+Question: Why did the Cosmic Lizard visit the library?
+Answer: to see if chickens were crossing it first.
+
+Question: Why did the Big Ben write a memoir?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the Mount Rushmore plant a garden?
+Answer: because it wanted to get to the punny side.
+
+Question: Why did the whispering willow go to space?
+Answer: because it was feeling a little sheepish.
+
+Question: Why did the diaper buy a jetpack?
+Answer: because it heard laughter is the best medicine.
+
+Question: Why did the witty wolf practice yoga?
+Answer: to escape the punchline police.
+
+Question: Why did the Joe Biden host a party?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the tiny turtle learn to dance?
+Answer: because even animals appreciate a good pun.
+
+Question: Why did the Mount Rushmore practice yoga?
+Answer: because nature called and it answered with laughter.
+
+Question: Why did the Statue of Liberty visit the library?
+Answer: to make history giggle.
+
+Question: Why did the Donald Trump start a podcast?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the Julius Caesar cook spaghetti?
+Answer: because the aliens told it dad jokes were universal.
+
+Question: Why did the bashful bunny juggle bananas?
+Answer: because it misread the sign that said "no pun intended".
+
+Question: Why did the bathroom mirror take up knitting?
+Answer: because the moon dared it.
+
+Question: Why did the stormy cloud take up knitting?
+Answer: because the GPS told it there was a joke ahead.
+
+Question: Why did the curious cat write a memoir?
+Answer: because it was feeling a little sheepish.

--- a/pages/api/openai.js
+++ b/pages/api/openai.js
@@ -1,4 +1,6 @@
 import OpenAI from 'openai';
+import fs from 'fs';
+import path from 'path';
 
 /*
  * When running locally without a valid API key (for example, during development
@@ -10,6 +12,13 @@ import OpenAI from 'openai';
  */
 let openai;
 if (process.env.MOCK_OPENAI === 'true' || !process.env.API_KEY) {
+  // Read the list of dad jokes once so we can serve a random one when mocking
+  const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt');
+  const jokes = fs
+    .readFileSync(jokesPath, 'utf-8')
+    .split('\n\n')
+    .filter(Boolean);
+
   // Define a mock responses API that mirrors the interface used below
   openai = {
     responses: {
@@ -17,15 +26,15 @@ if (process.env.MOCK_OPENAI === 'true' || !process.env.API_KEY) {
        * Mock implementation of `responses.create`.
        * When called without streaming, returns a dummy value (not used in this implementation).
        * When called with streaming enabled, returns an async generator that yields a
-       * fixed dad joke in the same `Question:`/`Answer:` format character by character.
+       * dad joke character by character from the local jokes file.
        */
       async create({ stream }) {
         if (!stream) {
           // No streaming call should be made without stream in this implementation
           return { output_text: '' };
         }
-        // Provide a static dad joke formatted with Question and Answer on separate lines
-        const joke = 'Question: Why did the pancake become a dad?\nAnswer: Because it had too much batter!';
+        // Select a random joke from the dataset
+        const joke = jokes[Math.floor(Math.random() * jokes.length)];
         async function* generator() {
           for (const char of joke) {
             // Wait a tiny bit between characters to better simulate streaming

--- a/pages/api/random-joke.js
+++ b/pages/api/random-joke.js
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req, res) {
+  const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt');
+  const jokes = fs.readFileSync(jokesPath, 'utf-8').split('\n\n').filter(Boolean);
+  const joke = jokes[Math.floor(Math.random() * jokes.length)];
+  res.status(200).json({ joke });
+}

--- a/pages/speak.js
+++ b/pages/speak.js
@@ -52,60 +52,14 @@ export default function SpeechHelper() {
     setIsLoadedValue(false);
   };
 
-  // load demo script
-  const loadDemoScript = () => {
-    setInputValue(`Hello there! This is a comprehensive test for the text-to-audio bot.
-We’re going to explore a wide range of speech patterns, sentence lengths, and tricky phrases to see how well you handle them.
-
-First, let’s start simple:
-The quick brown fox jumps over the lazy dog.
-A classic pangram containing every letter of the English alphabet.
-
-Now, a short tongue twister:
-She sells seashells by the seashore. The shells she sells are surely seashells.
-
-Alright—time for a shift in tone. Imagine you’re narrating an audiobook:
-
-“Under the pale silver moon, the ship’s sails billowed like ghostly wings, carrying the travelers toward an uncertain horizon. Each creak of the wooden boards whispered secrets of the deep.”
-
-Let’s try some numbers and dates:
-
-Today is Thursday, August 7th, 2025.
-
-My phone number is five five five, one two three, four five six seven.
-
-The total comes to $1,247.38 — including tax.
-
-Pi is approximately 3.14159.
-
-How about abbreviations and acronyms?
-NASA launched the Artemis II mission in 2024.
-I work in the R&D department at a company that uses AI, NLP, and IoT technologies.
-
-Now, testing emphasis and pauses:
-Wait… what did you just say?
-No. Absolutely not.
-Yes—well, maybe.
-I suppose… we could try it.
-
-A dramatic change in speed:
-Slowly, deliberately, he turned the key.
-Then—BANG!—the door flew open and the sound of rushing wind filled the room.
-
-Here’s a paragraph with mixed sentence structures:
-Sometimes, life moves at a steady pace. Other times, everything happens at once—emails, phone calls, deadlines, alarms. In those moments, clarity comes from a single breath. Inhale. Exhale. Focus. And then… keep going.
-
-For testing long continuous reading:
-“In the heart of the bustling city, where neon lights painted the night sky and the air hummed with the rhythm of countless footsteps, there lived a musician who played not for fame, nor for fortune, but for the fleeting moments when a stranger’s eyes would light up at the sound of his melody. His guitar was worn, its strings replaced countless times, yet each note carried the weight of his journey—stories of loss, hope, and the quiet beauty of persistence.”
-
-Finally, ending with a multilingual test:
-Bonjour, comment ça va? (French)
-Hola, me llamo Javier. (Spanish)
-Guten Tag, wie geht’s Ihnen? (German)
-こんにちは、元気ですか？ (Japanese)
-
-And that concludes the test script for the text-to-audio bot.
-If you’ve made it this far without a glitch—congratulations!`);
+  // load a random dad joke from the local dataset
+  const loadRandomJoke = async () => {
+    const res = await fetch('/api/random-joke');
+    const data = await res.json();
+    const [q, a] = data.joke.split('\n');
+    const question = q.replace(/^Question:\s*/i, '');
+    const answer = (a || '').replace(/^Answer:\s*/i, '');
+    setInputValue(`${question}          ${answer}`);
   };
 
   useEffect(() => {
@@ -165,7 +119,7 @@ If you’ve made it this far without a glitch—congratulations!`);
         </div>
         <div className={styles.buttonGroup}>
           <button className={styles.formbutton} onClick={sendDataToBackend}>Play</button>
-          <button className={styles.formbutton} onClick={loadDemoScript}>Load Demo Script</button>
+          <button className={styles.formbutton} onClick={loadRandomJoke}>Load Random Dad Joke</button>
         </div>
         {isLoaded && (
           <ReactAudioPlayer


### PR DESCRIPTION
## Summary
- add file with 1000 dad jokes covering various topics
- stream random jokes from dataset when OpenAI is mocked
- fetch random dad jokes for demo play on speak page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897421cff588328921773b08c478316