### PR TITLE
feat: add random dad joke prompt generator

### DIFF
--- a/data/dad_jokes.txt
+++ b/data/dad_jokes.txt
@@ -1,2999 +1,2999 @@
-Question: Why did the Alien from Mars cross the road?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the submarine juggle a harmonica, a scooter, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the jolly jaguar plant a garden?
-Answer: because nature called and it answered with laughter.
+Question: Why did the cloud bring a trombone, a cookie, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the singing river juggle bananas?
-Answer: to make history giggle.
+Question: Why did the banana balance a balloon, a helmet, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Abraham Lincoln start a podcast?
-Answer: because the coffee was too weak.
+Question: Why did the violin bring a trombone, a teapot, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Margaret Thatcher start a podcast?
-Answer: because the coffee was too weak.
+Question: Why did the penguin bring a umbrella, a hat, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Alien from Mars juggle bananas?
-Answer: to see if chickens were crossing it first.
+Question: Why did the toaster hide a pizza, a hat, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the rolling prairie plant a garden?
-Answer: because even animals appreciate a good pun.
+Question: Why did the robot balance a slinky, a harmonica, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Margaret Thatcher bake a cake?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the penguin juggle a harmonica, a helmet, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Big Ben join a comedy club?
-Answer: because it wanted to get to the punny side.
+Question: Why did the drone hide a helmet, a scooter, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the UFO Pilot plant a garden?
-Answer: to escape the punchline police.
+Question: Why did the banana wear a trombone, a balloon, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Golden Gate Bridge host a party?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the submarine bring a scooter, a trombone, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Angela Merkel join a comedy club?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the drone bring a helmet, a teapot, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mahatma Gandhi plant a garden?
-Answer: because the moon dared it.
+Question: Why did the robot hide a balloon, a teapot, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Queen Elizabeth II cross the road?
-Answer: because someone bet it a nickel.
+Question: Why did the violin balance a pizza, a cookie, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the hand sanitizer bake a cake?
-Answer: because it had nothing better to do.
+Question: Why did the penguin balance a teapot, a trombone, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Joe Biden juggle bananas?
-Answer: for the sake of comedic timing.
+Question: Why did the submarine hide a balloon, a teapot, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the bathroom mirror start a podcast?
-Answer: because the coffee was too weak.
+Question: Why did the cactus hide a backpack, a umbrella, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the plunger go to space?
-Answer: because it wanted to get to the punny side.
+Question: Why did the banana balance a backpack, a trombone, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Kim Jong-un learn to dance?
-Answer: because someone bet it a nickel.
+Question: Why did the pizza juggle a helmet, a slinky, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Statue of Liberty practice yoga?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the astronaut balance a pizza, a umbrella, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the zany zebra write a memoir?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the drone hide a backpack, a scooter, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the stormy cloud cook spaghetti?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the cloud balance a umbrella, a scooter, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the lazy dog buy a jetpack?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the submarine wear a scooter, a slinky, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Golden Gate Bridge go to space?
-Answer: because it wanted to get to the punny side.
+Question: Why did the unicorn bring a scooter, a backpack, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the glowing sunset take up knitting?
-Answer: because it was feeling a little sheepish.
+Question: Why did the turtle hide a teapot, a pizza, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the wild weasel host a party?
-Answer: because it had nothing better to do.
+Question: Why did the turtle juggle a slinky, a helmet, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Cosmic Lizard take up knitting?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the turtle balance a balloon, a teapot, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mahatma Gandhi write a memoir?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the unicorn hide a hat, a trombone, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Big Ben plant a garden?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the banana wear a pizza, a slinky, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the lazy dog train for a marathon?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the zebra hide a pizza, a harmonica, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Cosmic Lizard start a podcast?
-Answer: because it wanted to get to the punny side.
+Question: Why did the drone wear a teapot, a trombone, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the rolling prairie play the banjo?
-Answer: to prove it was a legend in its own time.
+Question: Why did the astronaut bring a pizza, a helmet, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Angela Merkel visit the library?
-Answer: to impress the grandchildren.
+Question: Why did the astronaut hide a pizza, a harmonica, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Angela Merkel join a comedy club?
-Answer: to prove it was a legend in its own time.
+Question: Why did the drone bring a cookie, a umbrella, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Martian Tourist play the banjo?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the turtle wear a cookie, a helmet, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the cheeky chicken paint a masterpiece?
-Answer: to see if chickens were crossing it first.
+Question: Why did the robot wear a trombone, a helmet, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Queen Elizabeth II practice yoga?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cloud juggle a trombone, a pizza, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Golden Gate Bridge start a podcast?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the aardvark hide a harmonica, a hat, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the polar ice cap join a comedy club?
-Answer: because nature called and it answered with laughter.
+Question: Why did the cloud balance a pizza, a harmonica, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the playful panda go to space?
-Answer: because potty humor is timeless.
+Question: Why did the astronaut balance a helmet, a trombone, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the tiny turtle bake a cake?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the aardvark wear a slinky, a harmonica, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the playful panda buy a jetpack?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the banana wear a trombone, a umbrella, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the funky flamingo bake a cake?
-Answer: because someone bet it a nickel.
+Question: Why did the drone juggle a umbrella, a trombone, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the glowing sunset plant a garden?
-Answer: because the moon dared it.
+Question: Why did the toaster balance a harmonica, a umbrella, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the tiny turtle practice yoga?
-Answer: because it wanted to get to the punny side.
+Question: Why did the turtle bring a scooter, a trombone, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the daring dolphin juggle bananas?
-Answer: because it was feeling a little sheepish.
+Question: Why did the submarine balance a hat, a trombone, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the wild weasel visit the library?
-Answer: to escape the punchline police.
+Question: Why did the cloud hide a helmet, a pizza, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Cosmic Lizard buy a jetpack?
-Answer: because someone bet it a nickel.
+Question: Why did the penguin bring a helmet, a backpack, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the diaper go to space?
-Answer: to impress the grandchildren.
+Question: Why did the astronaut juggle a helmet, a pizza, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the hand sanitizer take up knitting?
-Answer: because it was feeling a little sheepish.
+Question: Why did the submarine hide a scooter, a teapot, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Margaret Thatcher practice yoga?
-Answer: to impress the grandchildren.
+Question: Why did the pizza hide a helmet, a slinky, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the brave bear go to space?
-Answer: because it was feeling a little sheepish.
+Question: Why did the unicorn bring a balloon, a teapot, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the ancient oak tree take up knitting?
-Answer: because it was feeling a little sheepish.
+Question: Why did the violin wear a cookie, a balloon, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the dancing waterfall cross the road?
-Answer: because it was feeling a little sheepish.
+Question: Why did the robot juggle a scooter, a harmonica, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Alien from Mars write a memoir?
-Answer: because it wanted to get to the punny side.
+Question: Why did the cloud juggle a pizza, a harmonica, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet join a comedy club?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the banana balance a umbrella, a slinky, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the laughing llama join a comedy club?
-Answer: for the sake of comedic timing.
+Question: Why did the turtle hide a balloon, a teapot, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Eiffel Tower take up knitting?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the cactus balance a trombone, a slinky, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Stonehenge practice yoga?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the toaster bring a teapot, a pizza, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the funky flamingo open a cafe?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cactus juggle a helmet, a trombone, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Angela Merkel go to space?
-Answer: because it wanted to get to the punny side.
+Question: Why did the astronaut bring a cookie, a helmet, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mahatma Gandhi juggle bananas?
-Answer: to see if chickens were crossing it first.
+Question: Why did the pizza juggle a slinky, a backpack, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the curious cat take up knitting?
-Answer: because nature called and it answered with laughter.
+Question: Why did the unicorn bring a harmonica, a cookie, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Napoleon Bonaparte practice yoga?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cactus juggle a balloon, a scooter, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mahatma Gandhi join a comedy club?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the astronaut juggle a scooter, a trombone, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the mighty moose cross the road?
-Answer: because potty humor is timeless.
+Question: Why did the cloud hide a backpack, a cookie, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Barack Obama go to space?
-Answer: because nature called and it answered with laughter.
+Question: Why did the cactus balance a trombone, a harmonica, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the stormy cloud practice yoga?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cloud wear a scooter, a umbrella, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the tiny turtle study philosophy?
-Answer: because it had nothing better to do.
+Question: Why did the pizza juggle a slinky, a teapot, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the polar ice cap go to space?
-Answer: because it was feeling a little sheepish.
+Question: Why did the astronaut wear a umbrella, a slinky, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the hand sanitizer study philosophy?
-Answer: to make history giggle.
+Question: Why did the banana balance a slinky, a balloon, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Kim Jong-un host a party?
-Answer: for the sake of comedic timing.
+Question: Why did the cactus juggle a umbrella, a cookie, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Great Wall of China cross the road?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the penguin balance a umbrella, a pizza, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Eiffel Tower buy a jetpack?
-Answer: to escape the punchline police.
+Question: Why did the banana juggle a scooter, a pizza, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Genghis Khan study philosophy?
-Answer: because someone bet it a nickel.
+Question: Why did the submarine hide a scooter, a trombone, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Great Wall of China buy a jetpack?
-Answer: because even animals appreciate a good pun.
+Question: Why did the drone bring a trombone, a cookie, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the UFO Pilot learn to dance?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the violin hide a hat, a slinky, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the singing river host a party?
-Answer: for the sake of comedic timing.
+Question: Why did the penguin balance a pizza, a umbrella, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the sneaky raccoon juggle bananas?
-Answer: because it wanted to get to the punny side.
+Question: Why did the toaster balance a scooter, a backpack, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Winston Churchill practice yoga?
-Answer: for the sake of comedic timing.
+Question: Why did the banana hide a harmonica, a trombone, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Great Wall of China play the banjo?
-Answer: because nature called and it answered with laughter.
+Question: Why did the banana wear a harmonica, a teapot, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Nelson Mandela cross the road?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the astronaut hide a scooter, a pizza, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Winston Churchill start a podcast?
-Answer: because even animals appreciate a good pun.
+Question: Why did the robot bring a slinky, a trombone, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the desert cactus cross the road?
-Answer: because nature called and it answered with laughter.
+Question: Why did the robot wear a teapot, a helmet, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Statue of Liberty go to space?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the unicorn bring a backpack, a balloon, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the playful panda play the banjo?
-Answer: because someone bet it a nickel.
+Question: Why did the turtle bring a helmet, a umbrella, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Vladimir Putin learn to dance?
-Answer: to impress the grandchildren.
+Question: Why did the banana wear a teapot, a trombone, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet paper roll bake a cake?
-Answer: because even animals appreciate a good pun.
+Question: Why did the unicorn bring a pizza, a harmonica, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the rubber duck bake a cake?
-Answer: to make history giggle.
+Question: Why did the penguin hide a teapot, a pizza, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Winston Churchill take up knitting?
-Answer: because potty humor is timeless.
+Question: Why did the unicorn bring a scooter, a balloon, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Statue of Liberty juggle bananas?
-Answer: because it was feeling a little sheepish.
+Question: Why did the astronaut bring a cookie, a trombone, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the diaper practice yoga?
-Answer: because nature called and it answered with laughter.
+Question: Why did the penguin wear a helmet, a slinky, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the wild weasel plant a garden?
-Answer: because it wanted to get to the punny side.
+Question: Why did the aardvark bring a backpack, a slinky, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Alien from Mars paint a masterpiece?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the turtle juggle a pizza, a cookie, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the happy hamster juggle bananas?
-Answer: to impress the grandchildren.
+Question: Why did the zebra hide a teapot, a trombone, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet bake a cake?
-Answer: to impress the grandchildren.
+Question: Why did the zebra bring a trombone, a backpack, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet paper roll buy a jetpack?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the astronaut wear a helmet, a umbrella, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Taj Mahal practice yoga?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the zebra bring a cookie, a hat, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the polar ice cap bake a cake?
-Answer: because potty humor is timeless.
+Question: Why did the penguin wear a backpack, a balloon, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Eiffel Tower go to space?
-Answer: because it was feeling a little sheepish.
+Question: Why did the aardvark wear a harmonica, a teapot, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Martian Tourist take up knitting?
-Answer: to prove it was a legend in its own time.
+Question: Why did the unicorn wear a pizza, a umbrella, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Xi Jinping bake a cake?
-Answer: because the coffee was too weak.
+Question: Why did the violin hide a harmonica, a hat, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the singing river host a party?
-Answer: because even animals appreciate a good pun.
+Question: Why did the aardvark bring a umbrella, a pizza, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the E.T. open a cafe?
-Answer: to impress the grandchildren.
+Question: Why did the turtle hide a umbrella, a hat, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the whispering willow play the banjo?
-Answer: to see if chickens were crossing it first.
+Question: Why did the penguin juggle a umbrella, a helmet, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the sneaky raccoon open a cafe?
-Answer: because nature called and it answered with laughter.
+Question: Why did the violin hide a umbrella, a hat, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Alexander the Great paint a masterpiece?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the turtle hide a cookie, a pizza, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the funky flamingo juggle bananas?
-Answer: to impress the grandchildren.
+Question: Why did the cactus bring a hat, a slinky, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the George Washington cook spaghetti?
-Answer: because it was feeling a little sheepish.
+Question: Why did the banana hide a umbrella, a cookie, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Nelson Mandela open a cafe?
-Answer: because it wanted to get to the punny side.
+Question: Why did the toaster hide a harmonica, a scooter, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Vladimir Putin play the banjo?
-Answer: because it was feeling a little sheepish.
+Question: Why did the toaster hide a balloon, a trombone, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Cleopatra open a cafe?
-Answer: because it wanted to get to the punny side.
+Question: Why did the submarine bring a backpack, a helmet, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the singing river join a comedy club?
-Answer: because it was feeling a little sheepish.
+Question: Why did the robot balance a backpack, a umbrella, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Genghis Khan visit the library?
-Answer: because the moon dared it.
+Question: Why did the astronaut balance a helmet, a teapot, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the majestic mountain cook spaghetti?
-Answer: because the coffee was too weak.
+Question: Why did the astronaut hide a trombone, a umbrella, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Statue of Liberty write a memoir?
-Answer: because it was feeling a little sheepish.
+Question: Why did the drone bring a backpack, a slinky, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the soap dispenser learn to dance?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the cactus wear a pizza, a helmet, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Area 51 Visitor buy a jetpack?
-Answer: to escape the punchline police.
+Question: Why did the aardvark balance a cookie, a umbrella, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the majestic mountain plant a garden?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the violin juggle a harmonica, a slinky, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Angela Merkel go to space?
-Answer: to prove it was a legend in its own time.
+Question: Why did the robot bring a backpack, a trombone, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Pyramids of Giza play the banjo?
-Answer: because someone bet it a nickel.
+Question: Why did the cactus hide a umbrella, a trombone, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the sleepy sloth go to space?
-Answer: to see if chickens were crossing it first.
+Question: Why did the unicorn balance a scooter, a umbrella, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Mount Rushmore write a memoir?
-Answer: because nature called and it answered with laughter.
+Question: Why did the banana juggle a scooter, a trombone, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the lazy dog cross the road?
-Answer: because the coffee was too weak.
+Question: Why did the drone hide a cookie, a backpack, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the brave bear start a podcast?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the robot wear a trombone, a helmet, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the witty wolf open a cafe?
-Answer: because even animals appreciate a good pun.
+Question: Why did the cloud wear a scooter, a harmonica, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the hand sanitizer learn to dance?
-Answer: because someone bet it a nickel.
+Question: Why did the astronaut balance a scooter, a harmonica, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Galaxy Hitchhiker take up knitting?
-Answer: because the coffee was too weak.
+Question: Why did the aardvark wear a balloon, a umbrella, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bathroom scale study philosophy?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the zebra balance a trombone, a teapot, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Little Green Man plant a garden?
-Answer: because it had nothing better to do.
+Question: Why did the zebra bring a cookie, a backpack, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the majestic mountain cook spaghetti?
-Answer: because even animals appreciate a good pun.
+Question: Why did the turtle wear a backpack, a helmet, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Extraterrestrial Neighbor visit the library?
-Answer: to make history giggle.
+Question: Why did the submarine balance a backpack, a balloon, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Napoleon Bonaparte buy a jetpack?
-Answer: to prove it was a legend in its own time.
+Question: Why did the astronaut balance a hat, a helmet, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bathroom mirror cross the road?
-Answer: to prove it was a legend in its own time.
+Question: Why did the cactus balance a hat, a slinky, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the desert cactus bake a cake?
-Answer: for the sake of comedic timing.
+Question: Why did the aardvark bring a teapot, a cookie, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Extraterrestrial Neighbor paint a masterpiece?
-Answer: because potty humor is timeless.
+Question: Why did the violin bring a slinky, a pizza, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Mahatma Gandhi visit the library?
-Answer: because nature called and it answered with laughter.
+Question: Why did the violin wear a trombone, a hat, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the bathroom mirror learn to dance?
-Answer: because the moon dared it.
+Question: Why did the aardvark balance a umbrella, a harmonica, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the funky flamingo train for a marathon?
-Answer: because the moon dared it.
+Question: Why did the drone juggle a backpack, a umbrella, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the happy hamster play the banjo?
-Answer: to prove it was a legend in its own time.
+Question: Why did the submarine hide a harmonica, a helmet, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the rubber duck go to space?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the toaster bring a harmonica, a teapot, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the dancing waterfall play the banjo?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the robot juggle a trombone, a scooter, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the cheeky chicken host a party?
-Answer: to escape the punchline police.
+Question: Why did the penguin wear a pizza, a cookie, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the witty wolf go to space?
-Answer: because the coffee was too weak.
+Question: Why did the cloud bring a trombone, a balloon, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Area 51 Visitor start a podcast?
-Answer: because it was feeling a little sheepish.
+Question: Why did the pizza wear a hat, a harmonica, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the E.T. learn to dance?
-Answer: for the sake of comedic timing.
+Question: Why did the turtle wear a umbrella, a pizza, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the UFO Pilot juggle bananas?
-Answer: because even animals appreciate a good pun.
+Question: Why did the drone bring a umbrella, a pizza, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Joe Biden write a memoir?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the drone wear a harmonica, a balloon, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Vladimir Putin bake a cake?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the turtle wear a slinky, a harmonica, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the brave bear juggle bananas?
-Answer: because it had nothing better to do.
+Question: Why did the aardvark juggle a umbrella, a balloon, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mount Rushmore study philosophy?
-Answer: because it had nothing better to do.
+Question: Why did the robot bring a slinky, a pizza, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Space Invader join a comedy club?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cactus bring a harmonica, a cookie, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Golden Gate Bridge buy a jetpack?
-Answer: because someone bet it a nickel.
+Question: Why did the zebra bring a harmonica, a cookie, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Napoleon Bonaparte host a party?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the violin wear a teapot, a trombone, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the desert cactus take up knitting?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the zebra bring a scooter, a backpack, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the plunger write a memoir?
-Answer: to prove it was a legend in its own time.
+Question: Why did the cactus hide a teapot, a helmet, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the funky flamingo cross the road?
-Answer: because the coffee was too weak.
+Question: Why did the astronaut hide a helmet, a harmonica, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Donald Trump visit the library?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the aardvark juggle a helmet, a balloon, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the brave bear write a memoir?
-Answer: because nature called and it answered with laughter.
+Question: Why did the aardvark bring a hat, a slinky, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the sneaky raccoon study philosophy?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the unicorn bring a umbrella, a balloon, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Eiffel Tower buy a jetpack?
-Answer: to prove it was a legend in its own time.
+Question: Why did the toaster wear a hat, a teapot, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the mighty moose learn to dance?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the turtle balance a harmonica, a helmet, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Big Ben go to space?
-Answer: because it was feeling a little sheepish.
+Question: Why did the robot balance a umbrella, a backpack, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Kim Jong-un juggle bananas?
-Answer: to see if chickens were crossing it first.
+Question: Why did the zebra hide a slinky, a trombone, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Genghis Khan practice yoga?
-Answer: to escape the punchline police.
+Question: Why did the drone juggle a scooter, a helmet, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Area 51 Visitor start a podcast?
-Answer: to prove it was a legend in its own time.
+Question: Why did the unicorn hide a backpack, a harmonica, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Great Wall of China play the banjo?
-Answer: because the moon dared it.
+Question: Why did the astronaut bring a slinky, a harmonica, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Margaret Thatcher cross the road?
-Answer: to escape the punchline police.
+Question: Why did the turtle balance a umbrella, a slinky, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Queen Elizabeth II take up knitting?
-Answer: because potty humor is timeless.
+Question: Why did the astronaut juggle a helmet, a scooter, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Statue of Liberty visit the library?
-Answer: for the sake of comedic timing.
+Question: Why did the violin juggle a pizza, a hat, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Taj Mahal visit the library?
-Answer: because it was feeling a little sheepish.
+Question: Why did the zebra hide a slinky, a umbrella, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the plunger buy a jetpack?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the astronaut wear a scooter, a teapot, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Cleopatra buy a jetpack?
-Answer: because it was feeling a little sheepish.
+Question: Why did the turtle hide a trombone, a pizza, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Kim Jong-un cook spaghetti?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the cactus hide a hat, a pizza, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the whispering willow take up knitting?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the banana balance a harmonica, a backpack, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the mighty moose paint a masterpiece?
-Answer: because potty humor is timeless.
+Question: Why did the cactus wear a hat, a helmet, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the glowing sunset play the banjo?
-Answer: because nature called and it answered with laughter.
+Question: Why did the cloud balance a pizza, a helmet, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Margaret Thatcher buy a jetpack?
-Answer: to prove it was a legend in its own time.
+Question: Why did the violin hide a pizza, a umbrella, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the plunger cook spaghetti?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the aardvark wear a cookie, a scooter, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Cosmic Lizard practice yoga?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the robot hide a balloon, a slinky, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the mighty moose host a party?
-Answer: because the coffee was too weak.
+Question: Why did the robot juggle a hat, a umbrella, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the bathroom mirror buy a jetpack?
-Answer: because potty humor is timeless.
+Question: Why did the cloud juggle a trombone, a backpack, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the UFO Pilot train for a marathon?
-Answer: because the moon dared it.
+Question: Why did the submarine wear a balloon, a umbrella, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Cleopatra study philosophy?
-Answer: to see if chickens were crossing it first.
+Question: Why did the pizza hide a harmonica, a pizza, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Nelson Mandela write a memoir?
-Answer: because even animals appreciate a good pun.
+Question: Why did the pizza balance a teapot, a hat, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the rubber duck bake a cake?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the pizza juggle a helmet, a harmonica, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the polar ice cap open a cafe?
-Answer: because the moon dared it.
+Question: Why did the turtle balance a slinky, a helmet, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the toilet paper roll visit the library?
-Answer: because someone bet it a nickel.
+Question: Why did the robot juggle a hat, a backpack, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the dancing waterfall take up knitting?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the cactus bring a hat, a pizza, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the bathroom mirror host a party?
-Answer: to see if chickens were crossing it first.
+Question: Why did the robot juggle a harmonica, a pizza, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the toilet paper roll learn to dance?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine juggle a trombone, a umbrella, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Xi Jinping visit the library?
-Answer: because the moon dared it.
+Question: Why did the turtle juggle a cookie, a harmonica, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the lazy dog play the banjo?
-Answer: because potty humor is timeless.
+Question: Why did the violin balance a cookie, a scooter, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Galaxy Hitchhiker host a party?
-Answer: to prove it was a legend in its own time.
+Question: Why did the penguin balance a harmonica, a umbrella, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the brave bear open a cafe?
-Answer: to escape the punchline police.
+Question: Why did the robot juggle a scooter, a pizza, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Golden Gate Bridge go to space?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the banana hide a hat, a balloon, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Justin Trudeau juggle bananas?
-Answer: because it had nothing better to do.
+Question: Why did the penguin juggle a balloon, a backpack, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Julius Caesar paint a masterpiece?
-Answer: to see if chickens were crossing it first.
+Question: Why did the astronaut bring a pizza, a helmet, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the sleepy sloth study philosophy?
-Answer: to escape the punchline police.
+Question: Why did the unicorn wear a helmet, a scooter, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mona Lisa learn to dance?
-Answer: to make history giggle.
+Question: Why did the cactus balance a scooter, a helmet, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the UFO Pilot bake a cake?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the pizza juggle a umbrella, a slinky, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Joe Biden juggle bananas?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the cloud bring a trombone, a scooter, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Kim Jong-un start a podcast?
-Answer: because nature called and it answered with laughter.
+Question: Why did the penguin juggle a slinky, a harmonica, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Martian Tourist cross the road?
-Answer: to impress the grandchildren.
+Question: Why did the astronaut wear a cookie, a pizza, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the wild weasel practice yoga?
-Answer: because it wanted to get to the punny side.
+Question: Why did the pizza juggle a cookie, a hat, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Golden Gate Bridge buy a jetpack?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the banana balance a balloon, a pizza, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the daring dolphin train for a marathon?
-Answer: to prove it was a legend in its own time.
+Question: Why did the zebra wear a pizza, a slinky, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Cosmic Lizard open a cafe?
-Answer: to make history giggle.
+Question: Why did the banana juggle a trombone, a slinky, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Kim Jong-un play the banjo?
-Answer: because it had nothing better to do.
+Question: Why did the zebra juggle a umbrella, a harmonica, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Joe Biden play the banjo?
-Answer: because even animals appreciate a good pun.
+Question: Why did the drone hide a cookie, a trombone, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Vladimir Putin plant a garden?
-Answer: because potty humor is timeless.
+Question: Why did the aardvark bring a trombone, a scooter, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the air freshener train for a marathon?
-Answer: because even animals appreciate a good pun.
+Question: Why did the unicorn bring a trombone, a backpack, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the bashful bunny host a party?
-Answer: because the moon dared it.
+Question: Why did the cactus juggle a pizza, a helmet, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the jolly jaguar buy a jetpack?
-Answer: to escape the punchline police.
+Question: Why did the toaster balance a backpack, a cookie, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the cheeky chicken learn to dance?
-Answer: to escape the punchline police.
+Question: Why did the banana wear a slinky, a trombone, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the laughing llama take up knitting?
-Answer: because nature called and it answered with laughter.
+Question: Why did the pizza wear a slinky, a balloon, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the toilet paper roll cross the road?
-Answer: because the moon dared it.
+Question: Why did the cloud bring a slinky, a harmonica, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the whispering willow study philosophy?
-Answer: because potty humor is timeless.
+Question: Why did the drone hide a balloon, a trombone, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the toilet paint a masterpiece?
-Answer: for the sake of comedic timing.
+Question: Why did the aardvark juggle a helmet, a umbrella, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the ancient oak tree practice yoga?
-Answer: to prove it was a legend in its own time.
+Question: Why did the penguin juggle a scooter, a hat, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bathroom scale join a comedy club?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the zebra juggle a helmet, a hat, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the sleepy sloth cross the road?
-Answer: to prove it was a legend in its own time.
+Question: Why did the violin juggle a harmonica, a trombone, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Vladimir Putin cook spaghetti?
-Answer: because it wanted to get to the punny side.
+Question: Why did the zebra balance a backpack, a teapot, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the daring dolphin go to space?
-Answer: because it was feeling a little sheepish.
+Question: Why did the turtle bring a scooter, a pizza, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Statue of Liberty go to space?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the zebra balance a backpack, a teapot, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Extraterrestrial Neighbor bake a cake?
-Answer: because it wanted to get to the punny side.
+Question: Why did the cactus wear a hat, a balloon, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Kim Jong-un visit the library?
-Answer: to see if chickens were crossing it first.
+Question: Why did the pizza wear a slinky, a scooter, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Abraham Lincoln start a podcast?
-Answer: because the moon dared it.
+Question: Why did the cactus bring a backpack, a umbrella, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Little Green Man join a comedy club?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cloud hide a teapot, a hat, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bathroom scale visit the library?
-Answer: because nature called and it answered with laughter.
+Question: Why did the drone balance a hat, a trombone, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the George Washington learn to dance?
-Answer: to escape the punchline police.
+Question: Why did the astronaut bring a slinky, a hat, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the glowing sunset buy a jetpack?
-Answer: to escape the punchline police.
+Question: Why did the cloud wear a hat, a trombone, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Eiffel Tower cross the road?
-Answer: for the sake of comedic timing.
+Question: Why did the unicorn bring a hat, a cookie, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the majestic mountain train for a marathon?
-Answer: to prove it was a legend in its own time.
+Question: Why did the pizza balance a hat, a umbrella, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Eiffel Tower train for a marathon?
-Answer: for the sake of comedic timing.
+Question: Why did the toaster bring a balloon, a trombone, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the glowing sunset write a memoir?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the zebra hide a trombone, a cookie, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the spunky spider go to space?
-Answer: to prove it was a legend in its own time.
+Question: Why did the violin wear a harmonica, a umbrella, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the rubber duck buy a jetpack?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the penguin hide a umbrella, a backpack, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the sneaky raccoon go to space?
-Answer: because potty humor is timeless.
+Question: Why did the cloud balance a trombone, a hat, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Donald Trump cross the road?
-Answer: because the coffee was too weak.
+Question: Why did the toaster wear a pizza, a balloon, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the tiny turtle open a cafe?
-Answer: because it wanted to get to the punny side.
+Question: Why did the cloud wear a balloon, a trombone, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the rolling prairie paint a masterpiece?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the violin wear a umbrella, a teapot, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the mighty moose plant a garden?
-Answer: because someone bet it a nickel.
+Question: Why did the violin hide a hat, a harmonica, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the hand sanitizer take up knitting?
-Answer: to impress the grandchildren.
+Question: Why did the zebra balance a teapot, a pizza, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the playful panda train for a marathon?
-Answer: for the sake of comedic timing.
+Question: Why did the robot hide a teapot, a cookie, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the happy hamster visit the library?
-Answer: because someone bet it a nickel.
+Question: Why did the toaster juggle a backpack, a teapot, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the soap dispenser bake a cake?
-Answer: because nature called and it answered with laughter.
+Question: Why did the cactus balance a balloon, a scooter, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Mona Lisa take up knitting?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the drone bring a harmonica, a helmet, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the toilet paper roll buy a jetpack?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the toaster balance a trombone, a helmet, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Space Invader learn to dance?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the penguin hide a harmonica, a helmet, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the E.T. learn to dance?
-Answer: to prove it was a legend in its own time.
+Question: Why did the aardvark hide a helmet, a balloon, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Area 51 Visitor plant a garden?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the drone hide a helmet, a pizza, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Kim Jong-un practice yoga?
-Answer: because nature called and it answered with laughter.
+Question: Why did the turtle balance a umbrella, a cookie, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Space Invader go to space?
-Answer: because the moon dared it.
+Question: Why did the robot bring a backpack, a balloon, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the George Washington buy a jetpack?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the violin juggle a scooter, a umbrella, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Extraterrestrial Neighbor visit the library?
-Answer: to escape the punchline police.
+Question: Why did the cactus bring a pizza, a cookie, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the bathroom scale learn to dance?
-Answer: because it had nothing better to do.
+Question: Why did the cloud bring a backpack, a balloon, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Martian Tourist visit the library?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the astronaut hide a cookie, a umbrella, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Great Wall of China visit the library?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine hide a scooter, a umbrella, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Queen Elizabeth II bake a cake?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the toaster bring a cookie, a harmonica, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Margaret Thatcher buy a jetpack?
-Answer: because it had nothing better to do.
+Question: Why did the toaster juggle a scooter, a cookie, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Kim Jong-un study philosophy?
-Answer: for the sake of comedic timing.
+Question: Why did the pizza juggle a teapot, a harmonica, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Area 51 Visitor go to space?
-Answer: because the coffee was too weak.
+Question: Why did the penguin juggle a slinky, a cookie, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the toilet write a memoir?
-Answer: to impress the grandchildren.
+Question: Why did the astronaut bring a pizza, a slinky, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Stonehenge cook spaghetti?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cloud wear a hat, a umbrella, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Eiffel Tower learn to dance?
-Answer: because even animals appreciate a good pun.
+Question: Why did the submarine balance a cookie, a trombone, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the majestic mountain start a podcast?
-Answer: because it was feeling a little sheepish.
+Question: Why did the zebra wear a helmet, a teapot, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Galaxy Hitchhiker write a memoir?
-Answer: because it wanted to get to the punny side.
+Question: Why did the aardvark wear a cookie, a pizza, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Abraham Lincoln take up knitting?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the aardvark bring a hat, a umbrella, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the ancient oak tree go to space?
-Answer: because the moon dared it.
+Question: Why did the cactus bring a scooter, a harmonica, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Margaret Thatcher cross the road?
-Answer: because it wanted to get to the punny side.
+Question: Why did the turtle balance a slinky, a helmet, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Julius Caesar open a cafe?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the robot bring a balloon, a helmet, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Napoleon Bonaparte train for a marathon?
-Answer: to escape the punchline police.
+Question: Why did the turtle wear a cookie, a scooter, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the stormy cloud buy a jetpack?
-Answer: because it had nothing better to do.
+Question: Why did the toaster balance a cookie, a pizza, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Eiffel Tower go to space?
-Answer: because potty humor is timeless.
+Question: Why did the zebra wear a harmonica, a pizza, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Julius Caesar bake a cake?
-Answer: to escape the punchline police.
+Question: Why did the penguin balance a scooter, a teapot, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Donald Trump juggle bananas?
-Answer: to make history giggle.
+Question: Why did the submarine bring a trombone, a scooter, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the rubber duck buy a jetpack?
-Answer: because even animals appreciate a good pun.
+Question: Why did the pizza wear a helmet, a slinky, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Space Invader visit the library?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the zebra bring a balloon, a umbrella, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the wild weasel juggle bananas?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine juggle a helmet, a teapot, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the grumpy goat cross the road?
-Answer: to impress the grandchildren.
+Question: Why did the banana hide a helmet, a umbrella, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the grumpy goat practice yoga?
-Answer: because the moon dared it.
+Question: Why did the pizza juggle a umbrella, a balloon, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the bathroom scale juggle bananas?
-Answer: because it wanted to get to the punny side.
+Question: Why did the cloud bring a backpack, a hat, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the laughing llama paint a masterpiece?
-Answer: for the sake of comedic timing.
+Question: Why did the toaster wear a slinky, a cookie, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Joe Biden open a cafe?
-Answer: to make history giggle.
+Question: Why did the zebra bring a balloon, a trombone, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Nelson Mandela host a party?
-Answer: because even animals appreciate a good pun.
+Question: Why did the zebra bring a harmonica, a backpack, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Great Wall of China plant a garden?
-Answer: because even animals appreciate a good pun.
+Question: Why did the unicorn balance a pizza, a scooter, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Pyramids of Giza host a party?
-Answer: for the sake of comedic timing.
+Question: Why did the cactus bring a slinky, a cookie, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Xi Jinping study philosophy?
-Answer: because it was feeling a little sheepish.
+Question: Why did the cloud balance a scooter, a umbrella, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the UFO Pilot play the banjo?
-Answer: for the sake of comedic timing.
+Question: Why did the unicorn bring a backpack, a umbrella, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Xi Jinping buy a jetpack?
-Answer: because nature called and it answered with laughter.
+Question: Why did the astronaut juggle a backpack, a scooter, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Justin Trudeau write a memoir?
-Answer: because nature called and it answered with laughter.
+Question: Why did the banana bring a scooter, a backpack, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Cleopatra learn to dance?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the violin balance a cookie, a backpack, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the glowing sunset plant a garden?
-Answer: to prove it was a legend in its own time.
+Question: Why did the banana wear a scooter, a hat, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Vladimir Putin cook spaghetti?
-Answer: because it was feeling a little sheepish.
+Question: Why did the cloud juggle a helmet, a pizza, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bashful bunny juggle bananas?
-Answer: to escape the punchline police.
+Question: Why did the penguin wear a cookie, a hat, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the grumpy goat cross the road?
-Answer: because potty humor is timeless.
+Question: Why did the turtle bring a slinky, a hat, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Vladimir Putin bake a cake?
-Answer: to escape the punchline police.
+Question: Why did the pizza wear a helmet, a backpack, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Justin Trudeau play the banjo?
-Answer: to prove it was a legend in its own time.
+Question: Why did the unicorn juggle a teapot, a scooter, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Statue of Liberty plant a garden?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the submarine bring a harmonica, a teapot, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the glowing sunset juggle bananas?
-Answer: because someone bet it a nickel.
+Question: Why did the toaster bring a backpack, a trombone, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the stormy cloud juggle bananas?
-Answer: because potty humor is timeless.
+Question: Why did the violin bring a helmet, a backpack, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the sleepy sloth join a comedy club?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the robot balance a balloon, a helmet, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the majestic mountain study philosophy?
-Answer: to impress the grandchildren.
+Question: Why did the cactus balance a teapot, a slinky, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the spunky spider open a cafe?
-Answer: to make history giggle.
+Question: Why did the banana bring a helmet, a balloon, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mona Lisa join a comedy club?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the penguin juggle a umbrella, a trombone, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the brave bear start a podcast?
-Answer: because nature called and it answered with laughter.
+Question: Why did the zebra balance a harmonica, a slinky, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Great Wall of China train for a marathon?
-Answer: to escape the punchline police.
+Question: Why did the pizza juggle a pizza, a backpack, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Galaxy Hitchhiker play the banjo?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the aardvark juggle a cookie, a pizza, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Pyramids of Giza buy a jetpack?
-Answer: to escape the punchline police.
+Question: Why did the toaster bring a slinky, a scooter, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Eiffel Tower join a comedy club?
-Answer: because even animals appreciate a good pun.
+Question: Why did the drone balance a helmet, a umbrella, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Queen Elizabeth II juggle bananas?
-Answer: to make history giggle.
+Question: Why did the penguin hide a teapot, a helmet, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet paper roll cross the road?
-Answer: because the coffee was too weak.
+Question: Why did the cloud hide a umbrella, a backpack, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Area 51 Visitor buy a jetpack?
-Answer: because it wanted to get to the punny side.
+Question: Why did the robot balance a umbrella, a teapot, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Vladimir Putin host a party?
-Answer: to prove it was a legend in its own time.
+Question: Why did the submarine hide a slinky, a harmonica, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the wild weasel join a comedy club?
-Answer: to prove it was a legend in its own time.
+Question: Why did the aardvark balance a teapot, a scooter, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Abraham Lincoln cook spaghetti?
-Answer: because it had nothing better to do.
+Question: Why did the banana hide a backpack, a harmonica, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the playful panda study philosophy?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine juggle a teapot, a scooter, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet start a podcast?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the toaster hide a trombone, a helmet, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Donald Trump juggle bananas?
-Answer: to escape the punchline police.
+Question: Why did the turtle wear a teapot, a trombone, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the ancient oak tree visit the library?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the zebra hide a pizza, a helmet, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Statue of Liberty learn to dance?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the unicorn bring a harmonica, a backpack, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Martian Tourist visit the library?
-Answer: because it was feeling a little sheepish.
+Question: Why did the cactus balance a cookie, a teapot, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Julius Caesar join a comedy club?
-Answer: because it had nothing better to do.
+Question: Why did the cactus juggle a umbrella, a scooter, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the UFO Pilot juggle bananas?
-Answer: to prove it was a legend in its own time.
+Question: Why did the turtle hide a teapot, a balloon, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the rolling prairie plant a garden?
-Answer: because it was feeling a little sheepish.
+Question: Why did the violin juggle a helmet, a backpack, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the cheeky chicken host a party?
-Answer: because it wanted to get to the punny side.
+Question: Why did the cloud bring a trombone, a cookie, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mona Lisa buy a jetpack?
-Answer: because potty humor is timeless.
+Question: Why did the unicorn juggle a cookie, a trombone, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the curious cat buy a jetpack?
-Answer: because nature called and it answered with laughter.
+Question: Why did the robot hide a balloon, a slinky, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Extraterrestrial Neighbor start a podcast?
-Answer: to see if chickens were crossing it first.
+Question: Why did the banana balance a trombone, a balloon, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the grumpy goat visit the library?
-Answer: to prove it was a legend in its own time.
+Question: Why did the toaster wear a trombone, a backpack, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the sneaky raccoon practice yoga?
-Answer: because nature called and it answered with laughter.
+Question: Why did the submarine bring a trombone, a scooter, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the rolling prairie practice yoga?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine bring a pizza, a backpack, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Great Wall of China cook spaghetti?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the submarine wear a slinky, a backpack, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the air freshener bake a cake?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cloud hide a cookie, a hat, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the soap dispenser take up knitting?
-Answer: for the sake of comedic timing.
+Question: Why did the toaster hide a scooter, a umbrella, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the diaper practice yoga?
-Answer: because the coffee was too weak.
+Question: Why did the cloud juggle a trombone, a teapot, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the E.T. study philosophy?
-Answer: to impress the grandchildren.
+Question: Why did the cloud balance a balloon, a scooter, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the dancing waterfall plant a garden?
-Answer: to make history giggle.
+Question: Why did the drone juggle a cookie, a helmet, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Nelson Mandela cross the road?
-Answer: because even animals appreciate a good pun.
+Question: Why did the penguin hide a scooter, a slinky, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the lazy dog play the banjo?
-Answer: because potty humor is timeless.
+Question: Why did the zebra hide a umbrella, a balloon, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the sneaky raccoon learn to dance?
-Answer: to escape the punchline police.
+Question: Why did the aardvark hide a teapot, a harmonica, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Galaxy Hitchhiker practice yoga?
-Answer: because it was feeling a little sheepish.
+Question: Why did the zebra hide a pizza, a hat, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the stormy cloud join a comedy club?
-Answer: to see if chickens were crossing it first.
+Question: Why did the aardvark balance a scooter, a backpack, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Margaret Thatcher host a party?
-Answer: because the coffee was too weak.
+Question: Why did the toaster bring a umbrella, a hat, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Queen Elizabeth II start a podcast?
-Answer: because someone bet it a nickel.
+Question: Why did the aardvark juggle a slinky, a scooter, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Napoleon Bonaparte visit the library?
-Answer: to escape the punchline police.
+Question: Why did the banana bring a pizza, a helmet, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the stormy cloud study philosophy?
-Answer: because the moon dared it.
+Question: Why did the drone bring a cookie, a scooter, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Donald Trump host a party?
-Answer: for the sake of comedic timing.
+Question: Why did the toaster balance a helmet, a slinky, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Cosmic Lizard plant a garden?
-Answer: to make history giggle.
+Question: Why did the drone bring a helmet, a scooter, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the air freshener host a party?
-Answer: to escape the punchline police.
+Question: Why did the pizza balance a helmet, a hat, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Taj Mahal train for a marathon?
-Answer: to impress the grandchildren.
+Question: Why did the zebra balance a cookie, a hat, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the glowing sunset paint a masterpiece?
-Answer: because it had nothing better to do.
+Question: Why did the toaster bring a harmonica, a trombone, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mona Lisa learn to dance?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the cloud juggle a teapot, a umbrella, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Alexander the Great open a cafe?
-Answer: because the coffee was too weak.
+Question: Why did the pizza balance a balloon, a hat, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Winston Churchill start a podcast?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the toaster balance a cookie, a pizza, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the rubber duck train for a marathon?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the aardvark hide a harmonica, a scooter, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Queen Elizabeth II play the banjo?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the aardvark hide a pizza, a cookie, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Napoleon Bonaparte host a party?
-Answer: because potty humor is timeless.
+Question: Why did the robot juggle a trombone, a scooter, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the cheeky chicken practice yoga?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the violin balance a trombone, a umbrella, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Angela Merkel plant a garden?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cactus bring a harmonica, a hat, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Napoleon Bonaparte open a cafe?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the toaster hide a cookie, a trombone, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the bathroom mirror join a comedy club?
-Answer: because it was feeling a little sheepish.
+Question: Why did the robot hide a pizza, a slinky, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the jolly jaguar study philosophy?
-Answer: to escape the punchline police.
+Question: Why did the violin juggle a umbrella, a cookie, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the hand sanitizer plant a garden?
-Answer: because even animals appreciate a good pun.
+Question: Why did the turtle balance a umbrella, a hat, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the whispering willow practice yoga?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the astronaut juggle a slinky, a harmonica, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the playful panda cross the road?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cloud hide a balloon, a teapot, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Alexander the Great write a memoir?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cactus juggle a hat, a harmonica, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the plunger take up knitting?
-Answer: because even animals appreciate a good pun.
+Question: Why did the astronaut balance a cookie, a trombone, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the soap dispenser visit the library?
-Answer: to see if chickens were crossing it first.
+Question: Why did the violin wear a umbrella, a teapot, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the zany zebra visit the library?
-Answer: to make history giggle.
+Question: Why did the robot wear a pizza, a cookie, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the jolly jaguar host a party?
-Answer: because someone bet it a nickel.
+Question: Why did the penguin bring a scooter, a balloon, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the sneaky raccoon cross the road?
-Answer: because it wanted to get to the punny side.
+Question: Why did the turtle balance a scooter, a helmet, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Kim Jong-un plant a garden?
-Answer: because even animals appreciate a good pun.
+Question: Why did the cloud hide a cookie, a trombone, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Mahatma Gandhi juggle bananas?
-Answer: to see if chickens were crossing it first.
+Question: Why did the astronaut wear a cookie, a hat, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bashful bunny juggle bananas?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the penguin balance a backpack, a hat, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Extraterrestrial Neighbor juggle bananas?
-Answer: to prove it was a legend in its own time.
+Question: Why did the aardvark bring a cookie, a slinky, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mahatma Gandhi cross the road?
-Answer: because potty humor is timeless.
+Question: Why did the violin wear a teapot, a scooter, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Space Invader visit the library?
-Answer: for the sake of comedic timing.
+Question: Why did the unicorn balance a slinky, a backpack, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Nelson Mandela write a memoir?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the banana wear a trombone, a umbrella, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the stormy cloud write a memoir?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the submarine bring a teapot, a trombone, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the George Washington practice yoga?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the pizza bring a backpack, a slinky, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Margaret Thatcher learn to dance?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the turtle bring a balloon, a backpack, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the curious cat go to space?
-Answer: to prove it was a legend in its own time.
+Question: Why did the cloud bring a harmonica, a teapot, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the rolling prairie join a comedy club?
-Answer: for the sake of comedic timing.
+Question: Why did the banana bring a teapot, a balloon, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Angela Merkel join a comedy club?
-Answer: to make history giggle.
+Question: Why did the aardvark wear a harmonica, a pizza, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the spunky spider juggle bananas?
-Answer: because the moon dared it.
+Question: Why did the aardvark balance a trombone, a pizza, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the daring dolphin juggle bananas?
-Answer: because potty humor is timeless.
+Question: Why did the cloud hide a helmet, a teapot, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Eiffel Tower play the banjo?
-Answer: because the moon dared it.
+Question: Why did the submarine balance a balloon, a backpack, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Area 51 Visitor learn to dance?
-Answer: to impress the grandchildren.
+Question: Why did the banana bring a umbrella, a hat, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the witty wolf bake a cake?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the cactus wear a slinky, a trombone, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Alien from Mars take up knitting?
-Answer: to impress the grandchildren.
+Question: Why did the robot balance a pizza, a umbrella, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Queen Elizabeth II join a comedy club?
-Answer: because even animals appreciate a good pun.
+Question: Why did the astronaut hide a harmonica, a backpack, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the witty wolf cook spaghetti?
-Answer: because potty humor is timeless.
+Question: Why did the zebra wear a balloon, a trombone, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Great Wall of China visit the library?
-Answer: because it had nothing better to do.
+Question: Why did the pizza wear a cookie, a backpack, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mahatma Gandhi bake a cake?
-Answer: because the moon dared it.
+Question: Why did the penguin hide a helmet, a slinky, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the curious cat cross the road?
-Answer: for the sake of comedic timing.
+Question: Why did the drone hide a backpack, a balloon, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Barack Obama buy a jetpack?
-Answer: because it wanted to get to the punny side.
+Question: Why did the toaster juggle a slinky, a pizza, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Abraham Lincoln practice yoga?
-Answer: because the coffee was too weak.
+Question: Why did the penguin balance a helmet, a trombone, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the air freshener go to space?
-Answer: because potty humor is timeless.
+Question: Why did the aardvark juggle a helmet, a harmonica, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Little Green Man paint a masterpiece?
-Answer: because potty humor is timeless.
+Question: Why did the astronaut wear a teapot, a scooter, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the sneaky raccoon cross the road?
-Answer: because it wanted to get to the punny side.
+Question: Why did the penguin juggle a scooter, a harmonica, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Nelson Mandela take up knitting?
-Answer: because someone bet it a nickel.
+Question: Why did the penguin juggle a teapot, a slinky, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the sleepy sloth write a memoir?
-Answer: for the sake of comedic timing.
+Question: Why did the unicorn wear a scooter, a cookie, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the ancient oak tree write a memoir?
-Answer: because the coffee was too weak.
+Question: Why did the banana juggle a scooter, a helmet, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the whispering willow start a podcast?
-Answer: because nature called and it answered with laughter.
+Question: Why did the turtle bring a backpack, a scooter, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the curious cat cook spaghetti?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the banana bring a balloon, a teapot, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Winston Churchill write a memoir?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the astronaut wear a backpack, a umbrella, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the UFO Pilot go to space?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the zebra hide a trombone, a backpack, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the E.T. go to space?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cloud balance a cookie, a harmonica, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Margaret Thatcher study philosophy?
-Answer: to make history giggle.
+Question: Why did the pizza hide a teapot, a slinky, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mount Rushmore start a podcast?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the turtle wear a helmet, a hat, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Nelson Mandela open a cafe?
-Answer: because the coffee was too weak.
+Question: Why did the drone juggle a balloon, a harmonica, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the zany zebra open a cafe?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the aardvark wear a scooter, a backpack, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Alexander the Great juggle bananas?
-Answer: to escape the punchline police.
+Question: Why did the toaster hide a harmonica, a trombone, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mona Lisa visit the library?
-Answer: to escape the punchline police.
+Question: Why did the zebra wear a teapot, a backpack, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Donald Trump study philosophy?
-Answer: for the sake of comedic timing.
+Question: Why did the banana bring a scooter, a trombone, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the polar ice cap play the banjo?
-Answer: to prove it was a legend in its own time.
+Question: Why did the banana juggle a backpack, a hat, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the toilet paper roll bake a cake?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the pizza juggle a scooter, a teapot, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Mona Lisa open a cafe?
-Answer: because nature called and it answered with laughter.
+Question: Why did the penguin juggle a helmet, a harmonica, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Martian Tourist juggle bananas?
-Answer: because nature called and it answered with laughter.
+Question: Why did the astronaut juggle a umbrella, a trombone, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the soap dispenser juggle bananas?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cactus hide a trombone, a backpack, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Stonehenge study philosophy?
-Answer: to see if chickens were crossing it first.
+Question: Why did the drone hide a hat, a pizza, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mount Rushmore juggle bananas?
-Answer: because it wanted to get to the punny side.
+Question: Why did the turtle juggle a hat, a cookie, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the wild weasel practice yoga?
-Answer: to see if chickens were crossing it first.
+Question: Why did the turtle hide a harmonica, a trombone, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Queen Elizabeth II train for a marathon?
-Answer: because the coffee was too weak.
+Question: Why did the astronaut wear a helmet, a scooter, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the bathroom mirror bake a cake?
-Answer: because nature called and it answered with laughter.
+Question: Why did the zebra wear a balloon, a slinky, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the happy hamster study philosophy?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the astronaut juggle a cookie, a teapot, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the brave bear open a cafe?
-Answer: to make history giggle.
+Question: Why did the toaster wear a backpack, a scooter, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the E.T. start a podcast?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the pizza hide a umbrella, a hat, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the diaper buy a jetpack?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the violin bring a hat, a umbrella, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the toilet paper roll learn to dance?
-Answer: because even animals appreciate a good pun.
+Question: Why did the penguin bring a hat, a umbrella, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Kim Jong-un cross the road?
-Answer: because potty humor is timeless.
+Question: Why did the penguin bring a scooter, a hat, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Joe Biden host a party?
-Answer: to impress the grandchildren.
+Question: Why did the violin juggle a umbrella, a backpack, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Abraham Lincoln write a memoir?
-Answer: for the sake of comedic timing.
+Question: Why did the pizza balance a balloon, a scooter, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mount Rushmore bake a cake?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cactus wear a cookie, a pizza, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the polar ice cap plant a garden?
-Answer: because even animals appreciate a good pun.
+Question: Why did the toaster wear a harmonica, a slinky, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the George Washington open a cafe?
-Answer: because it wanted to get to the punny side.
+Question: Why did the turtle balance a harmonica, a cookie, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the brave bear plant a garden?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the unicorn hide a slinky, a backpack, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mahatma Gandhi cross the road?
-Answer: because it had nothing better to do.
+Question: Why did the toaster wear a pizza, a scooter, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the brave bear play the banjo?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the banana hide a trombone, a pizza, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Mount Rushmore open a cafe?
-Answer: to escape the punchline police.
+Question: Why did the banana wear a scooter, a balloon, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Alexander the Great cross the road?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the penguin bring a harmonica, a umbrella, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the curious cat buy a jetpack?
-Answer: because nature called and it answered with laughter.
+Question: Why did the zebra hide a scooter, a harmonica, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Statue of Liberty cook spaghetti?
-Answer: because the moon dared it.
+Question: Why did the penguin hide a teapot, a backpack, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the playful panda take up knitting?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the penguin balance a trombone, a hat, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the zany zebra learn to dance?
-Answer: because someone bet it a nickel.
+Question: Why did the cactus hide a umbrella, a teapot, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Alien from Mars host a party?
-Answer: because someone bet it a nickel.
+Question: Why did the drone bring a trombone, a umbrella, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Alien from Mars plant a garden?
-Answer: because potty humor is timeless.
+Question: Why did the toaster wear a helmet, a scooter, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the zany zebra practice yoga?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the submarine juggle a cookie, a backpack, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Kim Jong-un study philosophy?
-Answer: because it was feeling a little sheepish.
+Question: Why did the cloud hide a cookie, a umbrella, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the dancing waterfall visit the library?
-Answer: for the sake of comedic timing.
+Question: Why did the astronaut juggle a helmet, a scooter, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the brave bear take up knitting?
-Answer: to make history giggle.
+Question: Why did the robot wear a trombone, a umbrella, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Angela Merkel start a podcast?
-Answer: because potty humor is timeless.
+Question: Why did the robot juggle a pizza, a scooter, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mahatma Gandhi cook spaghetti?
-Answer: because the moon dared it.
+Question: Why did the turtle juggle a scooter, a backpack, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the singing river bake a cake?
-Answer: because the coffee was too weak.
+Question: Why did the zebra juggle a balloon, a scooter, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Nelson Mandela visit the library?
-Answer: because it was feeling a little sheepish.
+Question: Why did the violin juggle a pizza, a scooter, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the spunky spider join a comedy club?
-Answer: to escape the punchline police.
+Question: Why did the toaster balance a helmet, a teapot, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the whispering willow host a party?
-Answer: because potty humor is timeless.
+Question: Why did the banana balance a balloon, a trombone, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the witty wolf train for a marathon?
-Answer: because nature called and it answered with laughter.
+Question: Why did the submarine balance a trombone, a umbrella, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the sneaky raccoon buy a jetpack?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the penguin juggle a slinky, a trombone, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the E.T. start a podcast?
-Answer: to prove it was a legend in its own time.
+Question: Why did the drone juggle a slinky, a backpack, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Mount Rushmore join a comedy club?
-Answer: to make history giggle.
+Question: Why did the cloud bring a trombone, a backpack, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the bathroom scale open a cafe?
-Answer: because it wanted to get to the punny side.
+Question: Why did the astronaut hide a pizza, a slinky, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Statue of Liberty juggle bananas?
-Answer: for the sake of comedic timing.
+Question: Why did the unicorn hide a scooter, a pizza, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the plunger cook spaghetti?
-Answer: because it was feeling a little sheepish.
+Question: Why did the toaster balance a umbrella, a trombone, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Mona Lisa learn to dance?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the drone bring a hat, a cookie, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the ancient oak tree study philosophy?
-Answer: because the coffee was too weak.
+Question: Why did the toaster juggle a hat, a pizza, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Galaxy Hitchhiker buy a jetpack?
-Answer: because potty humor is timeless.
+Question: Why did the robot hide a backpack, a slinky, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the glowing sunset host a party?
-Answer: because someone bet it a nickel.
+Question: Why did the cloud balance a umbrella, a backpack, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the polar ice cap open a cafe?
-Answer: because even animals appreciate a good pun.
+Question: Why did the penguin bring a hat, a scooter, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the rolling prairie go to space?
-Answer: to impress the grandchildren.
+Question: Why did the cactus balance a umbrella, a trombone, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Margaret Thatcher open a cafe?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the toaster balance a pizza, a harmonica, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Mona Lisa study philosophy?
-Answer: because nature called and it answered with laughter.
+Question: Why did the robot juggle a helmet, a pizza, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Julius Caesar juggle bananas?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the drone hide a harmonica, a pizza, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Angela Merkel study philosophy?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the submarine wear a hat, a backpack, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the diaper take up knitting?
-Answer: to prove it was a legend in its own time.
+Question: Why did the unicorn juggle a backpack, a scooter, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mahatma Gandhi practice yoga?
-Answer: because someone bet it a nickel.
+Question: Why did the banana hide a harmonica, a hat, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the desert cactus train for a marathon?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the aardvark bring a scooter, a umbrella, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Mount Rushmore host a party?
-Answer: to make history giggle.
+Question: Why did the penguin hide a trombone, a slinky, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the wild weasel plant a garden?
-Answer: to see if chickens were crossing it first.
+Question: Why did the toaster balance a umbrella, a harmonica, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the witty wolf bake a cake?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cactus juggle a pizza, a cookie, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the zany zebra buy a jetpack?
-Answer: to impress the grandchildren.
+Question: Why did the penguin hide a umbrella, a balloon, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the bathroom mirror start a podcast?
-Answer: to see if chickens were crossing it first.
+Question: Why did the robot balance a harmonica, a scooter, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the happy hamster train for a marathon?
-Answer: because even animals appreciate a good pun.
+Question: Why did the aardvark juggle a harmonica, a pizza, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mount Rushmore practice yoga?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the violin balance a trombone, a hat, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Extraterrestrial Neighbor start a podcast?
-Answer: to see if chickens were crossing it first.
+Question: Why did the drone bring a helmet, a balloon, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the toilet paper roll host a party?
-Answer: to impress the grandchildren.
+Question: Why did the cloud juggle a harmonica, a backpack, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Justin Trudeau bake a cake?
-Answer: for the sake of comedic timing.
+Question: Why did the astronaut hide a umbrella, a harmonica, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Stonehenge write a memoir?
-Answer: for the sake of comedic timing.
+Question: Why did the penguin wear a pizza, a harmonica, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Winston Churchill write a memoir?
-Answer: because even animals appreciate a good pun.
+Question: Why did the pizza hide a cookie, a helmet, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the polar ice cap learn to dance?
-Answer: because even animals appreciate a good pun.
+Question: Why did the zebra balance a trombone, a teapot, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the bathroom mirror paint a masterpiece?
-Answer: because the coffee was too weak.
+Question: Why did the violin wear a pizza, a balloon, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Alien from Mars take up knitting?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the penguin hide a trombone, a pizza, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the tiny turtle open a cafe?
-Answer: because it was feeling a little sheepish.
+Question: Why did the submarine wear a trombone, a umbrella, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the dancing waterfall host a party?
-Answer: because the moon dared it.
+Question: Why did the aardvark juggle a trombone, a scooter, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the hand sanitizer host a party?
-Answer: to make history giggle.
+Question: Why did the robot hide a cookie, a balloon, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Donald Trump practice yoga?
-Answer: because the coffee was too weak.
+Question: Why did the drone hide a helmet, a harmonica, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the dancing waterfall paint a masterpiece?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the unicorn wear a slinky, a pizza, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Statue of Liberty write a memoir?
-Answer: because the coffee was too weak.
+Question: Why did the violin hide a trombone, a pizza, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the toilet paper roll bake a cake?
-Answer: to prove it was a legend in its own time.
+Question: Why did the astronaut balance a hat, a balloon, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Winston Churchill cross the road?
-Answer: to impress the grandchildren.
+Question: Why did the penguin balance a slinky, a balloon, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the soap dispenser practice yoga?
-Answer: because it was feeling a little sheepish.
+Question: Why did the zebra bring a teapot, a harmonica, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the sleepy sloth host a party?
-Answer: to escape the punchline police.
+Question: Why did the cactus juggle a harmonica, a teapot, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Xi Jinping bake a cake?
-Answer: because the coffee was too weak.
+Question: Why did the toaster balance a umbrella, a helmet, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Napoleon Bonaparte play the banjo?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the toaster bring a scooter, a hat, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the bathroom mirror go to space?
-Answer: because even animals appreciate a good pun.
+Question: Why did the toaster hide a teapot, a hat, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Donald Trump start a podcast?
-Answer: to impress the grandchildren.
+Question: Why did the cactus juggle a hat, a teapot, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Alien from Mars learn to dance?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the cloud hide a trombone, a teapot, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the brave bear juggle bananas?
-Answer: because the moon dared it.
+Question: Why did the violin bring a cookie, a hat, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the polar ice cap take up knitting?
-Answer: because even animals appreciate a good pun.
+Question: Why did the unicorn juggle a pizza, a balloon, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Little Green Man paint a masterpiece?
-Answer: to impress the grandchildren.
+Question: Why did the drone hide a teapot, a cookie, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Abraham Lincoln study philosophy?
-Answer: because it wanted to get to the punny side.
+Question: Why did the astronaut juggle a scooter, a backpack, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the witty wolf paint a masterpiece?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the cactus juggle a backpack, a helmet, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Martian Tourist go to space?
-Answer: to see if chickens were crossing it first.
+Question: Why did the robot balance a balloon, a backpack, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Joe Biden paint a masterpiece?
-Answer: to make history giggle.
+Question: Why did the aardvark balance a slinky, a teapot, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the polar ice cap write a memoir?
-Answer: because someone bet it a nickel.
+Question: Why did the zebra hide a umbrella, a backpack, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the majestic mountain host a party?
-Answer: because it wanted to get to the punny side.
+Question: Why did the banana wear a pizza, a slinky, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the mighty moose open a cafe?
-Answer: because it wanted to get to the punny side.
+Question: Why did the pizza balance a teapot, a balloon, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the witty wolf learn to dance?
-Answer: because it was feeling a little sheepish.
+Question: Why did the zebra hide a hat, a backpack, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Napoleon Bonaparte juggle bananas?
-Answer: because nature called and it answered with laughter.
+Question: Why did the cloud hide a scooter, a hat, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Justin Trudeau train for a marathon?
-Answer: to escape the punchline police.
+Question: Why did the toaster hide a slinky, a trombone, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Area 51 Visitor practice yoga?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cloud juggle a harmonica, a helmet, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Joe Biden host a party?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the aardvark bring a balloon, a backpack, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the singing river cook spaghetti?
-Answer: because someone bet it a nickel.
+Question: Why did the drone wear a cookie, a umbrella, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the soap dispenser visit the library?
-Answer: because the coffee was too weak.
+Question: Why did the zebra hide a teapot, a umbrella, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the cheeky chicken juggle bananas?
-Answer: because the coffee was too weak.
+Question: Why did the zebra hide a pizza, a cookie, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Space Invader take up knitting?
-Answer: because the moon dared it.
+Question: Why did the pizza juggle a umbrella, a helmet, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bathroom scale study philosophy?
-Answer: because potty humor is timeless.
+Question: Why did the astronaut wear a hat, a trombone, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Napoleon Bonaparte write a memoir?
-Answer: because someone bet it a nickel.
+Question: Why did the violin juggle a hat, a pizza, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Genghis Khan buy a jetpack?
-Answer: for the sake of comedic timing.
+Question: Why did the cactus bring a scooter, a backpack, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Great Wall of China cross the road?
-Answer: because even animals appreciate a good pun.
+Question: Why did the unicorn wear a balloon, a helmet, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the whispering willow study philosophy?
-Answer: because it had nothing better to do.
+Question: Why did the banana wear a hat, a trombone, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the toilet paper roll plant a garden?
-Answer: because it wanted to get to the punny side.
+Question: Why did the violin wear a harmonica, a pizza, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the jolly jaguar bake a cake?
-Answer: because nature called and it answered with laughter.
+Question: Why did the astronaut juggle a hat, a cookie, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Winston Churchill go to space?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the drone bring a harmonica, a hat, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the stormy cloud paint a masterpiece?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the drone balance a harmonica, a slinky, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Napoleon Bonaparte open a cafe?
-Answer: for the sake of comedic timing.
+Question: Why did the cloud juggle a pizza, a trombone, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the bashful bunny juggle bananas?
-Answer: to prove it was a legend in its own time.
+Question: Why did the toaster juggle a harmonica, a umbrella, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the whispering willow write a memoir?
-Answer: because the coffee was too weak.
+Question: Why did the aardvark bring a trombone, a hat, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Alien from Mars open a cafe?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the astronaut balance a helmet, a hat, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Abraham Lincoln study philosophy?
-Answer: because the coffee was too weak.
+Question: Why did the violin bring a teapot, a balloon, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Julius Caesar learn to dance?
-Answer: to see if chickens were crossing it first.
+Question: Why did the violin hide a balloon, a pizza, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mount Rushmore start a podcast?
-Answer: because it wanted to get to the punny side.
+Question: Why did the submarine balance a teapot, a scooter, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the soap dispenser host a party?
-Answer: because someone bet it a nickel.
+Question: Why did the robot wear a cookie, a teapot, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Alien from Mars open a cafe?
-Answer: because the coffee was too weak.
+Question: Why did the turtle hide a teapot, a umbrella, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Martian Tourist write a memoir?
-Answer: to impress the grandchildren.
+Question: Why did the submarine juggle a hat, a pizza, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Napoleon Bonaparte play the banjo?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cactus bring a cookie, a helmet, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mona Lisa plant a garden?
-Answer: to make history giggle.
+Question: Why did the zebra wear a slinky, a pizza, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the daring dolphin juggle bananas?
-Answer: to see if chickens were crossing it first.
+Question: Why did the robot hide a slinky, a hat, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the laughing llama practice yoga?
-Answer: to escape the punchline police.
+Question: Why did the cloud juggle a hat, a backpack, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Golden Gate Bridge learn to dance?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the drone balance a pizza, a balloon, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the toilet paper roll cross the road?
-Answer: to escape the punchline police.
+Question: Why did the astronaut juggle a cookie, a umbrella, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Great Wall of China cook spaghetti?
-Answer: to escape the punchline police.
+Question: Why did the aardvark juggle a hat, a backpack, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Cleopatra visit the library?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the banana bring a slinky, a teapot, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Great Wall of China learn to dance?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the aardvark wear a slinky, a harmonica, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the E.T. visit the library?
-Answer: to prove it was a legend in its own time.
+Question: Why did the penguin juggle a backpack, a balloon, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Angela Merkel buy a jetpack?
-Answer: because even animals appreciate a good pun.
+Question: Why did the cactus balance a scooter, a helmet, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the laughing llama go to space?
-Answer: for the sake of comedic timing.
+Question: Why did the cactus hide a scooter, a balloon, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the ancient oak tree play the banjo?
-Answer: to make history giggle.
+Question: Why did the cloud hide a helmet, a teapot, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the rolling prairie paint a masterpiece?
-Answer: because potty humor is timeless.
+Question: Why did the aardvark bring a helmet, a umbrella, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Cosmic Lizard train for a marathon?
-Answer: because someone bet it a nickel.
+Question: Why did the drone juggle a helmet, a umbrella, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the grumpy goat study philosophy?
-Answer: because potty humor is timeless.
+Question: Why did the robot juggle a teapot, a scooter, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the ancient oak tree go to space?
-Answer: because someone bet it a nickel.
+Question: Why did the drone hide a pizza, a balloon, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the polar ice cap join a comedy club?
-Answer: because potty humor is timeless.
+Question: Why did the toaster balance a balloon, a trombone, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the toilet paper roll visit the library?
-Answer: because the moon dared it.
+Question: Why did the aardvark wear a trombone, a harmonica, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the ancient oak tree study philosophy?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the unicorn wear a backpack, a pizza, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the happy hamster visit the library?
-Answer: because it was feeling a little sheepish.
+Question: Why did the violin hide a pizza, a hat, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mount Rushmore practice yoga?
-Answer: because someone bet it a nickel.
+Question: Why did the unicorn hide a harmonica, a helmet, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Pyramids of Giza practice yoga?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the pizza juggle a teapot, a cookie, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the polar ice cap study philosophy?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the aardvark hide a cookie, a helmet, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mona Lisa train for a marathon?
-Answer: to impress the grandchildren.
+Question: Why did the unicorn wear a backpack, a cookie, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the rubber duck visit the library?
-Answer: for the sake of comedic timing.
+Question: Why did the zebra balance a umbrella, a helmet, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Area 51 Visitor play the banjo?
-Answer: to escape the punchline police.
+Question: Why did the unicorn juggle a helmet, a scooter, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Alien from Mars paint a masterpiece?
-Answer: because potty humor is timeless.
+Question: Why did the pizza bring a balloon, a trombone, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the desert cactus train for a marathon?
-Answer: because the moon dared it.
+Question: Why did the submarine bring a cookie, a umbrella, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Eiffel Tower train for a marathon?
-Answer: to make history giggle.
+Question: Why did the toaster hide a trombone, a scooter, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Martian Tourist play the banjo?
-Answer: because nature called and it answered with laughter.
+Question: Why did the zebra balance a teapot, a umbrella, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the bashful bunny host a party?
-Answer: because it was feeling a little sheepish.
+Question: Why did the cactus bring a umbrella, a harmonica, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Xi Jinping take up knitting?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the penguin bring a harmonica, a pizza, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Queen Elizabeth II cook spaghetti?
-Answer: for the sake of comedic timing.
+Question: Why did the unicorn hide a umbrella, a teapot, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the glowing sunset write a memoir?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the drone hide a balloon, a umbrella, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Xi Jinping visit the library?
-Answer: because the moon dared it.
+Question: Why did the toaster wear a balloon, a backpack, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the E.T. practice yoga?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the turtle juggle a cookie, a umbrella, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Napoleon Bonaparte cross the road?
-Answer: because someone bet it a nickel.
+Question: Why did the drone balance a slinky, a teapot, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Eiffel Tower buy a jetpack?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cloud bring a harmonica, a slinky, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the mighty moose go to space?
-Answer: because potty humor is timeless.
+Question: Why did the astronaut bring a slinky, a trombone, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the laughing llama open a cafe?
-Answer: because the coffee was too weak.
+Question: Why did the aardvark bring a helmet, a hat, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Vladimir Putin study philosophy?
-Answer: because the coffee was too weak.
+Question: Why did the turtle wear a slinky, a umbrella, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Julius Caesar go to space?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the penguin bring a scooter, a trombone, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the mighty moose cook spaghetti?
-Answer: because it had nothing better to do.
+Question: Why did the toaster juggle a balloon, a cookie, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet paper roll train for a marathon?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cloud juggle a balloon, a trombone, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the mighty moose study philosophy?
-Answer: because the coffee was too weak.
+Question: Why did the turtle balance a backpack, a slinky, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the rubber duck train for a marathon?
-Answer: to make history giggle.
+Question: Why did the penguin balance a scooter, a teapot, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the tiny turtle play the banjo?
-Answer: to see if chickens were crossing it first.
+Question: Why did the drone juggle a umbrella, a scooter, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the wild weasel write a memoir?
-Answer: to escape the punchline police.
+Question: Why did the robot juggle a helmet, a slinky, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the tiny turtle open a cafe?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the astronaut wear a backpack, a trombone, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the singing river play the banjo?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the unicorn balance a cookie, a umbrella, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the mighty moose bake a cake?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the cloud juggle a balloon, a backpack, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Eiffel Tower write a memoir?
-Answer: because the coffee was too weak.
+Question: Why did the cloud juggle a hat, a helmet, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the tiny turtle cook spaghetti?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the banana bring a trombone, a backpack, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Extraterrestrial Neighbor start a podcast?
-Answer: to make history giggle.
+Question: Why did the submarine juggle a cookie, a scooter, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the happy hamster train for a marathon?
-Answer: to make history giggle.
+Question: Why did the drone hide a cookie, a balloon, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the sleepy sloth cross the road?
-Answer: because even animals appreciate a good pun.
+Question: Why did the astronaut balance a harmonica, a pizza, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Pyramids of Giza train for a marathon?
-Answer: to impress the grandchildren.
+Question: Why did the pizza bring a slinky, a harmonica, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the wild weasel take up knitting?
-Answer: because it was feeling a little sheepish.
+Question: Why did the unicorn bring a hat, a pizza, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the desert cactus play the banjo?
-Answer: to see if chickens were crossing it first.
+Question: Why did the submarine balance a pizza, a helmet, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the wild weasel paint a masterpiece?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cactus wear a slinky, a backpack, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Alexander the Great practice yoga?
-Answer: to see if chickens were crossing it first.
+Question: Why did the astronaut balance a harmonica, a pizza, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Big Ben write a memoir?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the cactus hide a teapot, a scooter, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Statue of Liberty host a party?
-Answer: to escape the punchline police.
+Question: Why did the aardvark bring a scooter, a slinky, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Space Invader practice yoga?
-Answer: because the coffee was too weak.
+Question: Why did the turtle juggle a backpack, a hat, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Space Invader bake a cake?
-Answer: because nature called and it answered with laughter.
+Question: Why did the violin juggle a slinky, a pizza, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the sleepy sloth visit the library?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the astronaut wear a backpack, a pizza, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Winston Churchill plant a garden?
-Answer: to impress the grandchildren.
+Question: Why did the drone balance a umbrella, a helmet, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Napoleon Bonaparte open a cafe?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the violin hide a backpack, a pizza, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Vladimir Putin study philosophy?
-Answer: because the coffee was too weak.
+Question: Why did the pizza wear a umbrella, a hat, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the mighty moose bake a cake?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the cloud bring a umbrella, a trombone, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the mighty moose take up knitting?
-Answer: to make history giggle.
+Question: Why did the aardvark balance a umbrella, a pizza, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Joe Biden paint a masterpiece?
-Answer: to see if chickens were crossing it first.
+Question: Why did the banana bring a umbrella, a helmet, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Great Wall of China cross the road?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the submarine wear a slinky, a umbrella, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the singing river join a comedy club?
-Answer: because it wanted to get to the punny side.
+Question: Why did the cloud bring a harmonica, a cookie, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the laughing llama plant a garden?
-Answer: to prove it was a legend in its own time.
+Question: Why did the violin juggle a balloon, a slinky, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Little Green Man cross the road?
-Answer: because nature called and it answered with laughter.
+Question: Why did the cloud wear a balloon, a hat, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Angela Merkel go to space?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the drone hide a harmonica, a teapot, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Space Invader juggle bananas?
-Answer: because it had nothing better to do.
+Question: Why did the astronaut hide a harmonica, a umbrella, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the glowing sunset study philosophy?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the robot bring a umbrella, a helmet, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Great Wall of China paint a masterpiece?
-Answer: because it was feeling a little sheepish.
+Question: Why did the penguin hide a harmonica, a cookie, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Martian Tourist paint a masterpiece?
-Answer: to see if chickens were crossing it first.
+Question: Why did the zebra hide a slinky, a scooter, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the air freshener plant a garden?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the zebra juggle a scooter, a helmet, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the happy hamster go to space?
-Answer: because potty humor is timeless.
+Question: Why did the toaster wear a backpack, a helmet, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the tiny turtle bake a cake?
-Answer: because nature called and it answered with laughter.
+Question: Why did the submarine wear a pizza, a slinky, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Galaxy Hitchhiker learn to dance?
-Answer: for the sake of comedic timing.
+Question: Why did the pizza balance a balloon, a scooter, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Statue of Liberty go to space?
-Answer: because potty humor is timeless.
+Question: Why did the submarine juggle a teapot, a slinky, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Mount Rushmore go to space?
-Answer: because the moon dared it.
+Question: Why did the cloud juggle a teapot, a trombone, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet cross the road?
-Answer: because someone bet it a nickel.
+Question: Why did the turtle wear a cookie, a hat, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Golden Gate Bridge study philosophy?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the penguin hide a cookie, a pizza, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the polar ice cap cross the road?
-Answer: because it was feeling a little sheepish.
+Question: Why did the submarine balance a umbrella, a harmonica, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Xi Jinping cook spaghetti?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the pizza hide a slinky, a balloon, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the UFO Pilot bake a cake?
-Answer: because potty humor is timeless.
+Question: Why did the pizza hide a pizza, a backpack, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the witty wolf visit the library?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the astronaut bring a scooter, a umbrella, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Galaxy Hitchhiker juggle bananas?
-Answer: because nature called and it answered with laughter.
+Question: Why did the submarine wear a cookie, a backpack, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the hand sanitizer plant a garden?
-Answer: to see if chickens were crossing it first.
+Question: Why did the drone hide a harmonica, a balloon, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mahatma Gandhi buy a jetpack?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the turtle juggle a backpack, a hat, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Stonehenge buy a jetpack?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cloud wear a harmonica, a umbrella, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the soap dispenser cross the road?
-Answer: for the sake of comedic timing.
+Question: Why did the robot wear a balloon, a harmonica, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the lazy dog bake a cake?
-Answer: because it wanted to get to the punny side.
+Question: Why did the penguin hide a teapot, a scooter, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Vladimir Putin open a cafe?
-Answer: because it had nothing better to do.
+Question: Why did the drone bring a umbrella, a scooter, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Galaxy Hitchhiker take up knitting?
-Answer: to see if chickens were crossing it first.
+Question: Why did the penguin juggle a hat, a harmonica, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the E.T. juggle bananas?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the robot balance a helmet, a hat, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the lazy dog plant a garden?
-Answer: because it had nothing better to do.
+Question: Why did the violin wear a teapot, a scooter, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Eiffel Tower play the banjo?
-Answer: because potty humor is timeless.
+Question: Why did the submarine hide a hat, a backpack, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Statue of Liberty practice yoga?
-Answer: because it wanted to get to the punny side.
+Question: Why did the aardvark hide a balloon, a cookie, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Taj Mahal bake a cake?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the aardvark wear a trombone, a cookie, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Kim Jong-un cook spaghetti?
-Answer: because nature called and it answered with laughter.
+Question: Why did the cloud bring a cookie, a pizza, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the soap dispenser study philosophy?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the zebra balance a harmonica, a trombone, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the stormy cloud play the banjo?
-Answer: to escape the punchline police.
+Question: Why did the zebra hide a backpack, a pizza, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Xi Jinping buy a jetpack?
-Answer: because even animals appreciate a good pun.
+Question: Why did the turtle juggle a hat, a cookie, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the tiny turtle write a memoir?
-Answer: because it had nothing better to do.
+Question: Why did the drone juggle a umbrella, a trombone, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Xi Jinping visit the library?
-Answer: because someone bet it a nickel.
+Question: Why did the submarine wear a slinky, a balloon, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the grumpy goat take up knitting?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the turtle balance a scooter, a harmonica, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Barack Obama cook spaghetti?
-Answer: to make history giggle.
+Question: Why did the zebra juggle a helmet, a backpack, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the witty wolf join a comedy club?
-Answer: to make history giggle.
+Question: Why did the drone wear a helmet, a harmonica, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the hand sanitizer learn to dance?
-Answer: because someone bet it a nickel.
+Question: Why did the toaster balance a harmonica, a umbrella, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Extraterrestrial Neighbor take up knitting?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the aardvark balance a pizza, a backpack, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Big Ben join a comedy club?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cactus hide a trombone, a harmonica, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the cheeky chicken host a party?
-Answer: to prove it was a legend in its own time.
+Question: Why did the aardvark juggle a slinky, a pizza, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the UFO Pilot bake a cake?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the aardvark juggle a balloon, a backpack, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Nelson Mandela play the banjo?
-Answer: because the moon dared it.
+Question: Why did the penguin hide a teapot, a harmonica, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Nelson Mandela host a party?
-Answer: to escape the punchline police.
+Question: Why did the astronaut balance a teapot, a umbrella, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the rolling prairie juggle bananas?
-Answer: to escape the punchline police.
+Question: Why did the penguin balance a balloon, a teapot, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Genghis Khan juggle bananas?
-Answer: to make history giggle.
+Question: Why did the cactus juggle a scooter, a pizza, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Nelson Mandela cook spaghetti?
-Answer: because the coffee was too weak.
+Question: Why did the zebra hide a scooter, a hat, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the ancient oak tree bake a cake?
-Answer: because someone bet it a nickel.
+Question: Why did the robot bring a backpack, a balloon, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Barack Obama cross the road?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the penguin hide a trombone, a helmet, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Statue of Liberty train for a marathon?
-Answer: because someone bet it a nickel.
+Question: Why did the penguin bring a balloon, a teapot, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the George Washington join a comedy club?
-Answer: because nature called and it answered with laughter.
+Question: Why did the pizza wear a trombone, a umbrella, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Justin Trudeau go to space?
-Answer: because potty humor is timeless.
+Question: Why did the aardvark balance a hat, a balloon, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the laughing llama write a memoir?
-Answer: because the coffee was too weak.
+Question: Why did the cactus wear a umbrella, a pizza, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the diaper go to space?
-Answer: because the moon dared it.
+Question: Why did the unicorn bring a cookie, a teapot, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Little Green Man visit the library?
-Answer: because it was feeling a little sheepish.
+Question: Why did the violin juggle a scooter, a cookie, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the desert cactus join a comedy club?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the robot bring a helmet, a scooter, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the cheeky chicken start a podcast?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the astronaut juggle a trombone, a slinky, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Julius Caesar study philosophy?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the robot hide a pizza, a teapot, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the bathroom scale practice yoga?
-Answer: to make history giggle.
+Question: Why did the zebra juggle a trombone, a balloon, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Abraham Lincoln plant a garden?
-Answer: to escape the punchline police.
+Question: Why did the cloud hide a harmonica, a umbrella, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Great Wall of China train for a marathon?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the banana bring a pizza, a helmet, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Justin Trudeau open a cafe?
-Answer: to escape the punchline police.
+Question: Why did the violin bring a backpack, a hat, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Extraterrestrial Neighbor study philosophy?
-Answer: because it wanted to get to the punny side.
+Question: Why did the robot bring a pizza, a helmet, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the brave bear learn to dance?
-Answer: for the sake of comedic timing.
+Question: Why did the submarine juggle a pizza, a helmet, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Space Invader practice yoga?
-Answer: because it had nothing better to do.
+Question: Why did the aardvark wear a pizza, a slinky, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the tiny turtle learn to dance?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the pizza wear a harmonica, a teapot, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the daring dolphin buy a jetpack?
-Answer: because it was feeling a little sheepish.
+Question: Why did the drone hide a backpack, a scooter, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bathroom mirror practice yoga?
-Answer: because it was feeling a little sheepish.
+Question: Why did the cactus balance a teapot, a scooter, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Great Wall of China start a podcast?
-Answer: to prove it was a legend in its own time.
+Question: Why did the penguin wear a backpack, a hat, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the brave bear bake a cake?
-Answer: because it had nothing better to do.
+Question: Why did the aardvark juggle a trombone, a backpack, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the funky flamingo take up knitting?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the toaster bring a scooter, a pizza, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the tiny turtle go to space?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the robot hide a harmonica, a umbrella, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Galaxy Hitchhiker paint a masterpiece?
-Answer: to prove it was a legend in its own time.
+Question: Why did the pizza balance a balloon, a scooter, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the George Washington learn to dance?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine bring a backpack, a hat, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Golden Gate Bridge train for a marathon?
-Answer: because potty humor is timeless.
+Question: Why did the robot hide a slinky, a umbrella, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mahatma Gandhi cross the road?
-Answer: because nature called and it answered with laughter.
+Question: Why did the aardvark wear a harmonica, a balloon, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Taj Mahal visit the library?
-Answer: because the coffee was too weak.
+Question: Why did the banana balance a cookie, a pizza, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Big Ben learn to dance?
-Answer: to prove it was a legend in its own time.
+Question: Why did the zebra wear a pizza, a hat, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the cheeky chicken start a podcast?
-Answer: because the moon dared it.
+Question: Why did the penguin juggle a helmet, a backpack, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the tiny turtle buy a jetpack?
-Answer: to prove it was a legend in its own time.
+Question: Why did the violin juggle a pizza, a hat, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Little Green Man study philosophy?
-Answer: to escape the punchline police.
+Question: Why did the aardvark hide a pizza, a harmonica, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Space Invader write a memoir?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the unicorn balance a helmet, a pizza, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the desert cactus paint a masterpiece?
-Answer: because it wanted to get to the punny side.
+Question: Why did the zebra wear a balloon, a scooter, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the mighty moose play the banjo?
-Answer: because the coffee was too weak.
+Question: Why did the cloud bring a cookie, a balloon, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the bashful bunny cook spaghetti?
-Answer: because it wanted to get to the punny side.
+Question: Why did the banana balance a backpack, a cookie, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Nelson Mandela take up knitting?
-Answer: because potty humor is timeless.
+Question: Why did the banana juggle a harmonica, a trombone, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the UFO Pilot cross the road?
-Answer: to impress the grandchildren.
+Question: Why did the aardvark wear a trombone, a backpack, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the mighty moose play the banjo?
-Answer: because it was feeling a little sheepish.
+Question: Why did the aardvark juggle a slinky, a cookie, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the bashful bunny cook spaghetti?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the toaster bring a slinky, a backpack, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the daring dolphin visit the library?
-Answer: because the coffee was too weak.
+Question: Why did the cloud balance a umbrella, a teapot, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the UFO Pilot buy a jetpack?
-Answer: for the sake of comedic timing.
+Question: Why did the submarine bring a hat, a slinky, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Abraham Lincoln play the banjo?
-Answer: because the coffee was too weak.
+Question: Why did the violin wear a helmet, a pizza, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the George Washington start a podcast?
-Answer: because someone bet it a nickel.
+Question: Why did the cactus bring a slinky, a umbrella, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the sleepy sloth start a podcast?
-Answer: to make history giggle.
+Question: Why did the pizza bring a hat, a balloon, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Nelson Mandela visit the library?
-Answer: because someone bet it a nickel.
+Question: Why did the turtle hide a balloon, a teapot, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Pyramids of Giza play the banjo?
-Answer: for the sake of comedic timing.
+Question: Why did the cactus juggle a backpack, a slinky, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the soap dispenser host a party?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the pizza juggle a hat, a scooter, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Margaret Thatcher learn to dance?
-Answer: because it was feeling a little sheepish.
+Question: Why did the cloud bring a teapot, a trombone, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the funky flamingo plant a garden?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cloud juggle a umbrella, a slinky, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the UFO Pilot go to space?
-Answer: because the coffee was too weak.
+Question: Why did the drone juggle a umbrella, a scooter, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the George Washington take up knitting?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the astronaut wear a cookie, a harmonica, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the singing river paint a masterpiece?
-Answer: for the sake of comedic timing.
+Question: Why did the submarine juggle a trombone, a hat, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Vladimir Putin bake a cake?
-Answer: for the sake of comedic timing.
+Question: Why did the zebra balance a helmet, a harmonica, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Julius Caesar practice yoga?
-Answer: for the sake of comedic timing.
+Question: Why did the violin bring a slinky, a helmet, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the desert cactus play the banjo?
-Answer: because nature called and it answered with laughter.
+Question: Why did the banana juggle a umbrella, a hat, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Napoleon Bonaparte start a podcast?
-Answer: because potty humor is timeless.
+Question: Why did the cactus bring a trombone, a backpack, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Nelson Mandela learn to dance?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cactus hide a cookie, a helmet, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the soap dispenser play the banjo?
-Answer: because it wanted to get to the punny side.
+Question: Why did the turtle juggle a teapot, a scooter, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the brave bear take up knitting?
-Answer: to see if chickens were crossing it first.
+Question: Why did the banana balance a umbrella, a helmet, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the daring dolphin buy a jetpack?
-Answer: because it was feeling a little sheepish.
+Question: Why did the astronaut hide a hat, a pizza, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the toilet train for a marathon?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the submarine balance a trombone, a umbrella, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Taj Mahal juggle bananas?
-Answer: because it had nothing better to do.
+Question: Why did the cactus balance a slinky, a cookie, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Alexander the Great train for a marathon?
-Answer: to escape the punchline police.
+Question: Why did the toaster bring a scooter, a helmet, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Pyramids of Giza train for a marathon?
-Answer: because someone bet it a nickel.
+Question: Why did the astronaut juggle a scooter, a trombone, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the wild weasel buy a jetpack?
-Answer: to prove it was a legend in its own time.
+Question: Why did the robot bring a balloon, a pizza, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the daring dolphin go to space?
-Answer: because it wanted to get to the punny side.
+Question: Why did the cactus juggle a backpack, a scooter, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the sleepy sloth bake a cake?
-Answer: because the coffee was too weak.
+Question: Why did the violin hide a slinky, a pizza, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Vladimir Putin host a party?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the pizza juggle a trombone, a harmonica, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the stormy cloud join a comedy club?
-Answer: because someone bet it a nickel.
+Question: Why did the unicorn wear a hat, a scooter, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the lazy dog juggle bananas?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the unicorn wear a helmet, a hat, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Great Wall of China host a party?
-Answer: because the coffee was too weak.
+Question: Why did the robot hide a harmonica, a backpack, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the desert cactus buy a jetpack?
-Answer: because potty humor is timeless.
+Question: Why did the cactus juggle a hat, a backpack, and a scooter?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Joe Biden train for a marathon?
-Answer: because it had nothing better to do.
+Question: Why did the drone juggle a helmet, a umbrella, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the mighty moose cook spaghetti?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the banana wear a backpack, a pizza, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the diaper practice yoga?
-Answer: to impress the grandchildren.
+Question: Why did the zebra wear a helmet, a pizza, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the hand sanitizer play the banjo?
-Answer: to escape the punchline police.
+Question: Why did the zebra wear a helmet, a umbrella, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Cleopatra train for a marathon?
-Answer: because it was feeling a little sheepish.
+Question: Why did the submarine balance a slinky, a backpack, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the E.T. play the banjo?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cloud wear a trombone, a helmet, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Abraham Lincoln bake a cake?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the zebra juggle a teapot, a umbrella, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the glowing sunset visit the library?
-Answer: because it wanted to get to the punny side.
+Question: Why did the turtle bring a hat, a helmet, and a scooter?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the grumpy goat paint a masterpiece?
-Answer: because the coffee was too weak.
+Question: Why did the drone balance a helmet, a trombone, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Justin Trudeau start a podcast?
-Answer: because it wanted to get to the punny side.
+Question: Why did the aardvark wear a trombone, a slinky, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Barack Obama paint a masterpiece?
-Answer: because it wanted to get to the punny side.
+Question: Why did the aardvark bring a slinky, a scooter, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the George Washington study philosophy?
-Answer: because potty humor is timeless.
+Question: Why did the submarine bring a helmet, a slinky, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Eiffel Tower cross the road?
-Answer: to see if chickens were crossing it first.
+Question: Why did the violin balance a pizza, a backpack, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the playful panda play the banjo?
-Answer: because potty humor is timeless.
+Question: Why did the cactus hide a harmonica, a hat, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Martian Tourist cook spaghetti?
-Answer: because it had nothing better to do.
+Question: Why did the violin juggle a scooter, a pizza, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the hand sanitizer cross the road?
-Answer: because potty humor is timeless.
+Question: Why did the unicorn balance a trombone, a helmet, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Statue of Liberty practice yoga?
-Answer: to see if chickens were crossing it first.
+Question: Why did the unicorn juggle a teapot, a backpack, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Taj Mahal cook spaghetti?
-Answer: because someone bet it a nickel.
+Question: Why did the banana wear a hat, a backpack, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the air freshener cook spaghetti?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the violin bring a teapot, a slinky, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the polar ice cap bake a cake?
-Answer: to see if chickens were crossing it first.
+Question: Why did the drone wear a hat, a backpack, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Joe Biden study philosophy?
-Answer: because the coffee was too weak.
+Question: Why did the toaster bring a backpack, a scooter, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Joe Biden cross the road?
-Answer: because the moon dared it.
+Question: Why did the cloud bring a helmet, a slinky, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Abraham Lincoln write a memoir?
-Answer: to escape the punchline police.
+Question: Why did the turtle balance a cookie, a pizza, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the lazy dog cross the road?
-Answer: to make history giggle.
+Question: Why did the submarine juggle a umbrella, a cookie, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Donald Trump paint a masterpiece?
-Answer: because potty humor is timeless.
+Question: Why did the submarine juggle a backpack, a balloon, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the hand sanitizer study philosophy?
-Answer: to prove it was a legend in its own time.
+Question: Why did the unicorn wear a scooter, a harmonica, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Mahatma Gandhi bake a cake?
-Answer: to make history giggle.
+Question: Why did the cloud bring a scooter, a hat, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the laughing llama learn to dance?
-Answer: because someone bet it a nickel.
+Question: Why did the cloud wear a umbrella, a cookie, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the ancient oak tree paint a masterpiece?
-Answer: because it had nothing better to do.
+Question: Why did the penguin hide a harmonica, a cookie, and a backpack?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Nelson Mandela start a podcast?
-Answer: to prove it was a legend in its own time.
+Question: Why did the cloud wear a umbrella, a balloon, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the dancing waterfall host a party?
-Answer: because nature called and it answered with laughter.
+Question: Why did the astronaut hide a trombone, a slinky, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Xi Jinping visit the library?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the robot juggle a trombone, a pizza, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the grumpy goat paint a masterpiece?
-Answer: to prove it was a legend in its own time.
+Question: Why did the robot bring a harmonica, a hat, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Mahatma Gandhi buy a jetpack?
-Answer: to impress the grandchildren.
+Question: Why did the violin bring a scooter, a slinky, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mount Rushmore go to space?
-Answer: because even animals appreciate a good pun.
+Question: Why did the cloud bring a teapot, a slinky, and a harmonica?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Donald Trump join a comedy club?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the zebra balance a slinky, a helmet, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the polar ice cap visit the library?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the banana juggle a cookie, a pizza, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the bathroom mirror play the banjo?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the robot juggle a helmet, a slinky, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Great Wall of China go to space?
-Answer: because the coffee was too weak.
+Question: Why did the astronaut wear a helmet, a backpack, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the plunger train for a marathon?
-Answer: because the coffee was too weak.
+Question: Why did the pizza wear a trombone, a balloon, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the stormy cloud study philosophy?
-Answer: because even animals appreciate a good pun.
+Question: Why did the submarine juggle a trombone, a slinky, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Space Invader play the banjo?
-Answer: because it wanted to get to the punny side.
+Question: Why did the robot hide a hat, a pizza, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Pyramids of Giza juggle bananas?
-Answer: because someone bet it a nickel.
+Question: Why did the turtle juggle a cookie, a backpack, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mount Rushmore study philosophy?
-Answer: for the sake of comedic timing.
+Question: Why did the cloud juggle a hat, a teapot, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the happy hamster go to space?
-Answer: because the coffee was too weak.
+Question: Why did the turtle balance a teapot, a pizza, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the brave bear host a party?
-Answer: because the moon dared it.
+Question: Why did the cloud hide a slinky, a trombone, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Great Wall of China buy a jetpack?
-Answer: because it had nothing better to do.
+Question: Why did the toaster balance a scooter, a backpack, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Alexander the Great join a comedy club?
-Answer: to prove it was a legend in its own time.
+Question: Why did the violin bring a hat, a backpack, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Genghis Khan play the banjo?
-Answer: to impress the grandchildren.
+Question: Why did the pizza hide a umbrella, a teapot, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the diaper paint a masterpiece?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the aardvark wear a pizza, a helmet, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the hand sanitizer start a podcast?
-Answer: because the coffee was too weak.
+Question: Why did the submarine juggle a harmonica, a hat, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the sleepy sloth juggle bananas?
-Answer: because the moon dared it.
+Question: Why did the turtle bring a trombone, a harmonica, and a balloon?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the majestic mountain practice yoga?
-Answer: because it wanted to get to the punny side.
+Question: Why did the toaster juggle a slinky, a pizza, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the bashful bunny write a memoir?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the robot balance a balloon, a pizza, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the funky flamingo play the banjo?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the zebra juggle a balloon, a hat, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Martian Tourist cross the road?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the penguin balance a harmonica, a balloon, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Stonehenge practice yoga?
-Answer: because potty humor is timeless.
+Question: Why did the aardvark bring a helmet, a teapot, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Donald Trump juggle bananas?
-Answer: to make history giggle.
+Question: Why did the turtle hide a backpack, a hat, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Julius Caesar learn to dance?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the banana balance a pizza, a balloon, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the mighty moose cook spaghetti?
-Answer: because the coffee was too weak.
+Question: Why did the violin bring a hat, a teapot, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the tiny turtle start a podcast?
-Answer: to escape the punchline police.
+Question: Why did the unicorn hide a harmonica, a balloon, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Space Invader study philosophy?
-Answer: because even animals appreciate a good pun.
+Question: Why did the drone juggle a slinky, a trombone, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Barack Obama write a memoir?
-Answer: because even animals appreciate a good pun.
+Question: Why did the zebra bring a pizza, a balloon, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the glowing sunset start a podcast?
-Answer: because the moon dared it.
+Question: Why did the pizza balance a harmonica, a helmet, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the dancing waterfall join a comedy club?
-Answer: to impress the grandchildren.
+Question: Why did the drone balance a pizza, a umbrella, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the air freshener cross the road?
-Answer: because even animals appreciate a good pun.
+Question: Why did the zebra wear a helmet, a backpack, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mona Lisa join a comedy club?
-Answer: because it was feeling a little sheepish.
+Question: Why did the unicorn bring a backpack, a hat, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Napoleon Bonaparte cook spaghetti?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine juggle a umbrella, a cookie, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Genghis Khan host a party?
-Answer: to make history giggle.
+Question: Why did the penguin hide a pizza, a cookie, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the toilet bake a cake?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine wear a slinky, a umbrella, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the polar ice cap go to space?
-Answer: because it had nothing better to do.
+Question: Why did the drone wear a pizza, a harmonica, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the majestic mountain host a party?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the toaster balance a balloon, a cookie, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Stonehenge buy a jetpack?
-Answer: because even animals appreciate a good pun.
+Question: Why did the banana hide a hat, a scooter, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the plunger learn to dance?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the astronaut bring a harmonica, a trombone, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Martian Tourist train for a marathon?
-Answer: because nature called and it answered with laughter.
+Question: Why did the banana bring a hat, a umbrella, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the playful panda join a comedy club?
-Answer: to see if chickens were crossing it first.
+Question: Why did the zebra juggle a balloon, a umbrella, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the singing river go to space?
-Answer: because the coffee was too weak.
+Question: Why did the submarine hide a slinky, a scooter, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Queen Elizabeth II start a podcast?
-Answer: because the moon dared it.
+Question: Why did the turtle juggle a backpack, a scooter, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Extraterrestrial Neighbor join a comedy club?
-Answer: because the moon dared it.
+Question: Why did the banana wear a pizza, a helmet, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Taj Mahal bake a cake?
-Answer: because even animals appreciate a good pun.
+Question: Why did the zebra hide a trombone, a slinky, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the diaper host a party?
-Answer: for the sake of comedic timing.
+Question: Why did the unicorn juggle a helmet, a umbrella, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Xi Jinping buy a jetpack?
-Answer: because someone bet it a nickel.
+Question: Why did the turtle juggle a trombone, a harmonica, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the stormy cloud open a cafe?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the cloud hide a harmonica, a umbrella, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the spunky spider bake a cake?
-Answer: to make history giggle.
+Question: Why did the drone hide a helmet, a umbrella, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Abraham Lincoln host a party?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the robot bring a backpack, a hat, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the diaper train for a marathon?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the submarine bring a pizza, a scooter, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the laughing llama buy a jetpack?
-Answer: to escape the punchline police.
+Question: Why did the penguin hide a backpack, a helmet, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Donald Trump plant a garden?
-Answer: because someone bet it a nickel.
+Question: Why did the drone wear a scooter, a harmonica, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Mahatma Gandhi learn to dance?
-Answer: because potty humor is timeless.
+Question: Why did the cactus bring a trombone, a pizza, and a balloon?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the desert cactus go to space?
-Answer: to impress the grandchildren.
+Question: Why did the pizza bring a backpack, a helmet, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the rubber duck paint a masterpiece?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the penguin juggle a harmonica, a slinky, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the playful panda study philosophy?
-Answer: because nature called and it answered with laughter.
+Question: Why did the unicorn balance a trombone, a scooter, and a helmet?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the playful panda host a party?
-Answer: because it wanted to get to the punny side.
+Question: Why did the cactus balance a pizza, a umbrella, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the bathroom mirror play the banjo?
-Answer: because the coffee was too weak.
+Question: Why did the turtle juggle a hat, a trombone, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Napoleon Bonaparte plant a garden?
-Answer: because it had nothing better to do.
+Question: Why did the turtle hide a scooter, a harmonica, and a trombone?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the UFO Pilot paint a masterpiece?
-Answer: because the coffee was too weak.
+Question: Why did the banana juggle a umbrella, a balloon, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the grumpy goat join a comedy club?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the toaster balance a scooter, a cookie, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Donald Trump buy a jetpack?
-Answer: for the sake of comedic timing.
+Question: Why did the submarine wear a helmet, a slinky, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bashful bunny write a memoir?
-Answer: because the coffee was too weak.
+Question: Why did the toaster balance a balloon, a helmet, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Stonehenge cook spaghetti?
-Answer: to escape the punchline police.
+Question: Why did the submarine bring a harmonica, a teapot, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Barack Obama take up knitting?
-Answer: to escape the punchline police.
+Question: Why did the zebra juggle a teapot, a cookie, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Alien from Mars open a cafe?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the zebra bring a backpack, a teapot, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Galaxy Hitchhiker open a cafe?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the unicorn juggle a harmonica, a slinky, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the plunger learn to dance?
-Answer: because it had nothing better to do.
+Question: Why did the submarine hide a cookie, a helmet, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Angela Merkel host a party?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the aardvark juggle a scooter, a backpack, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the wild weasel study philosophy?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the penguin wear a trombone, a pizza, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Extraterrestrial Neighbor take up knitting?
-Answer: because nature called and it answered with laughter.
+Question: Why did the drone balance a helmet, a balloon, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the toilet paper roll open a cafe?
-Answer: because the coffee was too weak.
+Question: Why did the toaster hide a hat, a scooter, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Julius Caesar start a podcast?
-Answer: because it was feeling a little sheepish.
+Question: Why did the banana wear a scooter, a slinky, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the whispering willow train for a marathon?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the robot bring a pizza, a hat, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Julius Caesar train for a marathon?
-Answer: because it had nothing better to do.
+Question: Why did the drone bring a balloon, a backpack, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the ancient oak tree train for a marathon?
-Answer: because even animals appreciate a good pun.
+Question: Why did the pizza wear a scooter, a helmet, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the stormy cloud take up knitting?
-Answer: because the moon dared it.
+Question: Why did the toaster wear a scooter, a backpack, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Genghis Khan juggle bananas?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the violin balance a slinky, a backpack, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Space Invader learn to dance?
-Answer: to impress the grandchildren.
+Question: Why did the violin juggle a slinky, a hat, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mahatma Gandhi cook spaghetti?
-Answer: because it had nothing better to do.
+Question: Why did the turtle bring a umbrella, a trombone, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the plunger paint a masterpiece?
-Answer: because even animals appreciate a good pun.
+Question: Why did the submarine hide a cookie, a harmonica, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the plunger paint a masterpiece?
-Answer: to escape the punchline police.
+Question: Why did the robot bring a pizza, a backpack, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the polar ice cap open a cafe?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cloud hide a umbrella, a scooter, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Kim Jong-un write a memoir?
-Answer: because it was feeling a little sheepish.
+Question: Why did the turtle wear a harmonica, a slinky, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the sleepy sloth write a memoir?
-Answer: to impress the grandchildren.
+Question: Why did the drone balance a umbrella, a scooter, and a slinky?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Kim Jong-un train for a marathon?
-Answer: for the sake of comedic timing.
+Question: Why did the unicorn juggle a hat, a pizza, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the toilet host a party?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the unicorn balance a balloon, a trombone, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the desert cactus take up knitting?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the aardvark hide a slinky, a pizza, and a hat?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Extraterrestrial Neighbor plant a garden?
-Answer: for the sake of comedic timing.
+Question: Why did the cactus bring a umbrella, a teapot, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the zany zebra plant a garden?
-Answer: for the sake of comedic timing.
+Question: Why did the drone wear a scooter, a slinky, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the air freshener juggle bananas?
-Answer: because potty humor is timeless.
+Question: Why did the turtle juggle a backpack, a hat, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Alien from Mars cross the road?
-Answer: to escape the punchline police.
+Question: Why did the astronaut balance a slinky, a scooter, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the wild weasel go to space?
-Answer: to see if chickens were crossing it first.
+Question: Why did the drone balance a harmonica, a cookie, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Extraterrestrial Neighbor plant a garden?
-Answer: to impress the grandchildren.
+Question: Why did the cactus wear a slinky, a umbrella, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the polar ice cap cross the road?
-Answer: because the moon dared it.
+Question: Why did the turtle wear a teapot, a backpack, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the E.T. take up knitting?
-Answer: because someone bet it a nickel.
+Question: Why did the zebra juggle a cookie, a hat, and a backpack?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Napoleon Bonaparte bake a cake?
-Answer: to make history giggle.
+Question: Why did the violin hide a teapot, a hat, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the rubber duck visit the library?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the robot bring a trombone, a harmonica, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Abraham Lincoln start a podcast?
-Answer: to escape the punchline police.
+Question: Why did the penguin wear a umbrella, a harmonica, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Nelson Mandela bake a cake?
-Answer: to impress the grandchildren.
+Question: Why did the penguin hide a balloon, a teapot, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Abraham Lincoln take up knitting?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the banana juggle a helmet, a cookie, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Cosmic Lizard plant a garden?
-Answer: to impress the grandchildren.
+Question: Why did the turtle wear a backpack, a pizza, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the curious cat bake a cake?
-Answer: to impress the grandchildren.
+Question: Why did the unicorn balance a cookie, a pizza, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the bathroom mirror buy a jetpack?
-Answer: because potty humor is timeless.
+Question: Why did the turtle juggle a cookie, a slinky, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the zany zebra cross the road?
-Answer: to escape the punchline police.
+Question: Why did the pizza wear a pizza, a scooter, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the tiny turtle cross the road?
-Answer: because it wanted to get to the punny side.
+Question: Why did the astronaut wear a umbrella, a hat, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the polar ice cap practice yoga?
-Answer: to make history giggle.
+Question: Why did the penguin hide a umbrella, a scooter, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the laughing llama write a memoir?
-Answer: to prove it was a legend in its own time.
+Question: Why did the cloud balance a hat, a umbrella, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the stormy cloud take up knitting?
-Answer: because the moon dared it.
+Question: Why did the unicorn bring a umbrella, a slinky, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the zany zebra write a memoir?
-Answer: because potty humor is timeless.
+Question: Why did the pizza bring a umbrella, a cookie, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the dancing waterfall play the banjo?
-Answer: to make history giggle.
+Question: Why did the pizza juggle a trombone, a pizza, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the daring dolphin plant a garden?
-Answer: to make history giggle.
+Question: Why did the toaster bring a umbrella, a balloon, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the E.T. host a party?
-Answer: for the sake of comedic timing.
+Question: Why did the cloud bring a umbrella, a balloon, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the diaper play the banjo?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the violin bring a harmonica, a helmet, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the hand sanitizer join a comedy club?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the turtle bring a harmonica, a pizza, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Cosmic Lizard start a podcast?
-Answer: because the moon dared it.
+Question: Why did the pizza wear a trombone, a helmet, and a cookie?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the sneaky raccoon join a comedy club?
-Answer: to escape the punchline police.
+Question: Why did the zebra balance a trombone, a hat, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the jolly jaguar go to space?
-Answer: because it had nothing better to do.
+Question: Why did the cloud wear a hat, a balloon, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the cheeky chicken start a podcast?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the drone juggle a backpack, a scooter, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the brave bear go to space?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the zebra juggle a hat, a balloon, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the witty wolf train for a marathon?
-Answer: to escape the punchline police.
+Question: Why did the drone bring a trombone, a cookie, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the happy hamster practice yoga?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the cactus bring a balloon, a helmet, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Extraterrestrial Neighbor play the banjo?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the penguin bring a harmonica, a trombone, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Area 51 Visitor take up knitting?
-Answer: because even animals appreciate a good pun.
+Question: Why did the cloud balance a trombone, a cookie, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Eiffel Tower open a cafe?
-Answer: to escape the punchline police.
+Question: Why did the pizza wear a hat, a umbrella, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the lazy dog cross the road?
-Answer: to escape the punchline police.
+Question: Why did the submarine hide a umbrella, a cookie, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Napoleon Bonaparte cook spaghetti?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the astronaut balance a teapot, a harmonica, and a slinky?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the tiny turtle take up knitting?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine wear a trombone, a balloon, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bashful bunny practice yoga?
-Answer: to impress the grandchildren.
+Question: Why did the aardvark bring a umbrella, a scooter, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the lazy dog visit the library?
-Answer: to see if chickens were crossing it first.
+Question: Why did the aardvark bring a harmonica, a balloon, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Mona Lisa practice yoga?
-Answer: because it wanted to get to the punny side.
+Question: Why did the zebra juggle a balloon, a pizza, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Donald Trump cook spaghetti?
-Answer: to impress the grandchildren.
+Question: Why did the drone juggle a helmet, a slinky, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the bathroom mirror host a party?
-Answer: because the moon dared it.
+Question: Why did the turtle balance a backpack, a cookie, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the desert cactus plant a garden?
-Answer: to impress the grandchildren.
+Question: Why did the violin juggle a helmet, a pizza, and a umbrella?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Space Invader open a cafe?
-Answer: to see if chickens were crossing it first.
+Question: Why did the turtle hide a harmonica, a slinky, and a pizza?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Big Ben bake a cake?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the robot balance a backpack, a teapot, and a trombone?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Stonehenge study philosophy?
-Answer: to make history giggle.
+Question: Why did the drone wear a scooter, a umbrella, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Extraterrestrial Neighbor juggle bananas?
-Answer: to make history giggle.
+Question: Why did the cactus wear a umbrella, a hat, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the funky flamingo practice yoga?
-Answer: because the coffee was too weak.
+Question: Why did the cactus wear a pizza, a harmonica, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the diaper take up knitting?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the penguin balance a umbrella, a hat, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the whispering willow bake a cake?
-Answer: because it was feeling a little sheepish.
+Question: Why did the unicorn balance a pizza, a trombone, and a cookie?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Cosmic Lizard train for a marathon?
-Answer: to escape the punchline police.
+Question: Why did the robot balance a umbrella, a hat, and a scooter?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Great Wall of China practice yoga?
-Answer: to impress the grandchildren.
+Question: Why did the astronaut balance a balloon, a slinky, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the stormy cloud juggle bananas?
-Answer: to make history giggle.
+Question: Why did the banana wear a umbrella, a teapot, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the polar ice cap learn to dance?
-Answer: to impress the grandchildren.
+Question: Why did the pizza hide a umbrella, a teapot, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the rubber duck practice yoga?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the unicorn bring a balloon, a teapot, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Big Ben play the banjo?
-Answer: because potty humor is timeless.
+Question: Why did the drone hide a hat, a cookie, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the witty wolf host a party?
-Answer: to impress the grandchildren.
+Question: Why did the aardvark hide a hat, a backpack, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Winston Churchill play the banjo?
-Answer: because it had nothing better to do.
+Question: Why did the cactus hide a hat, a backpack, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Winston Churchill go to space?
-Answer: to make history giggle.
+Question: Why did the toaster wear a pizza, a cookie, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Queen Elizabeth II juggle bananas?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cloud bring a balloon, a scooter, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Angela Merkel train for a marathon?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the cactus hide a harmonica, a pizza, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the toilet juggle bananas?
-Answer: because the moon dared it.
+Question: Why did the submarine hide a trombone, a helmet, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the toilet take up knitting?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the pizza balance a scooter, a umbrella, and a backpack?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Nelson Mandela train for a marathon?
-Answer: to make history giggle.
+Question: Why did the submarine hide a cookie, a helmet, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the brave bear juggle bananas?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the toaster wear a hat, a umbrella, and a helmet?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Big Ben bake a cake?
-Answer: because the moon dared it.
+Question: Why did the robot balance a pizza, a umbrella, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the brave bear learn to dance?
-Answer: because nature called and it answered with laughter.
+Question: Why did the turtle juggle a hat, a trombone, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Big Ben buy a jetpack?
-Answer: to escape the punchline police.
+Question: Why did the zebra wear a harmonica, a hat, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the ancient oak tree write a memoir?
-Answer: because potty humor is timeless.
+Question: Why did the banana balance a balloon, a helmet, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Joe Biden open a cafe?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the submarine balance a cookie, a teapot, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the rubber duck paint a masterpiece?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the astronaut hide a helmet, a pizza, and a hat?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Winston Churchill cross the road?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the submarine bring a cookie, a scooter, and a trombone?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Statue of Liberty plant a garden?
-Answer: for the sake of comedic timing.
+Question: Why did the cloud balance a backpack, a cookie, and a scooter?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the glowing sunset learn to dance?
-Answer: to prove it was a legend in its own time.
+Question: Why did the unicorn hide a teapot, a pizza, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Abraham Lincoln buy a jetpack?
-Answer: because potty humor is timeless.
+Question: Why did the cloud juggle a balloon, a helmet, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the curious cat go to space?
-Answer: because nature called and it answered with laughter.
+Question: Why did the violin hide a pizza, a helmet, and a teapot?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Donald Trump plant a garden?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the submarine wear a slinky, a cookie, and a harmonica?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the majestic mountain play the banjo?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the banana balance a slinky, a scooter, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Martian Tourist cross the road?
-Answer: for the sake of comedic timing.
+Question: Why did the drone wear a cookie, a helmet, and a harmonica?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the air freshener cook spaghetti?
-Answer: for the sake of comedic timing.
+Question: Why did the pizza wear a hat, a teapot, and a umbrella?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Statue of Liberty practice yoga?
-Answer: because someone bet it a nickel.
+Question: Why did the robot hide a backpack, a pizza, and a helmet?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the funky flamingo open a cafe?
-Answer: because nature called and it answered with laughter.
+Question: Why did the robot wear a slinky, a scooter, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the dancing waterfall learn to dance?
-Answer: because the moon dared it.
+Question: Why did the penguin juggle a umbrella, a pizza, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Nelson Mandela buy a jetpack?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the banana balance a slinky, a balloon, and a umbrella?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the mighty moose host a party?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the violin balance a pizza, a harmonica, and a umbrella?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Barack Obama visit the library?
-Answer: because it wanted to get to the punny side.
+Question: Why did the banana hide a teapot, a hat, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the wild weasel write a memoir?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the zebra juggle a harmonica, a slinky, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Martian Tourist cook spaghetti?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the astronaut juggle a backpack, a pizza, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Mahatma Gandhi open a cafe?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the cactus juggle a pizza, a trombone, and a slinky?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the laughing llama go to space?
-Answer: to make history giggle.
+Question: Why did the banana bring a trombone, a harmonica, and a hat?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Pyramids of Giza plant a garden?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the banana balance a helmet, a hat, and a balloon?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Mount Rushmore learn to dance?
-Answer: for the sake of comedic timing.
+Question: Why did the violin hide a cookie, a pizza, and a slinky?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the funky flamingo take up knitting?
-Answer: because nature called and it answered with laughter.
+Question: Why did the aardvark bring a cookie, a teapot, and a umbrella?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the curious cat open a cafe?
-Answer: to prove it was a legend in its own time.
+Question: Why did the turtle bring a harmonica, a trombone, and a slinky?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Nelson Mandela plant a garden?
-Answer: because it wanted to get to the punny side.
+Question: Why did the banana wear a hat, a trombone, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Space Invader open a cafe?
-Answer: to prove it was a legend in its own time.
+Question: Why did the cactus juggle a hat, a harmonica, and a cookie?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the curious cat cross the road?
-Answer: because it wanted to get to the punny side.
+Question: Why did the astronaut wear a balloon, a hat, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the desert cactus bake a cake?
-Answer: because the moon dared it.
+Question: Why did the toaster juggle a pizza, a scooter, and a harmonica?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the daring dolphin visit the library?
-Answer: for the sake of comedic timing.
+Question: Why did the cloud juggle a harmonica, a hat, and a teapot?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the sleepy sloth visit the library?
-Answer: to escape the punchline police.
+Question: Why did the drone balance a balloon, a teapot, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the toilet open a cafe?
-Answer: because it wanted to get to the punny side.
+Question: Why did the turtle wear a cookie, a trombone, and a teapot?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the Justin Trudeau cook spaghetti?
-Answer: because it wanted to get to the punny side.
+Question: Why did the penguin hide a slinky, a helmet, and a pizza?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Great Wall of China cook spaghetti?
-Answer: because it was feeling a little sheepish.
+Question: Why did the toaster juggle a hat, a slinky, and a trombone?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the daring dolphin juggle bananas?
-Answer: because the moon dared it.
+Question: Why did the unicorn wear a pizza, a scooter, and a harmonica?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Space Invader cross the road?
-Answer: because the coffee was too weak.
+Question: Why did the pizza wear a harmonica, a slinky, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Napoleon Bonaparte juggle bananas?
-Answer: because it wanted to get to the punny side.
+Question: Why did the penguin bring a balloon, a teapot, and a pizza?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the witty wolf visit the library?
-Answer: to escape the punchline police.
+Question: Why did the banana wear a teapot, a cookie, and a hat?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the George Washington host a party?
-Answer: to see if chickens were crossing it first.
+Question: Why did the banana hide a harmonica, a hat, and a teapot?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Space Invader train for a marathon?
-Answer: because national treasure status gets boring without humor.
+Question: Why did the astronaut hide a backpack, a slinky, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the Cosmic Lizard visit the library?
-Answer: to see if chickens were crossing it first.
+Question: Why did the cloud wear a helmet, a harmonica, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Big Ben write a memoir?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the aardvark balance a teapot, a helmet, and a pizza?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Mount Rushmore plant a garden?
-Answer: because it wanted to get to the punny side.
+Question: Why did the banana balance a umbrella, a cookie, and a balloon?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the whispering willow go to space?
-Answer: because it was feeling a little sheepish.
+Question: Why did the aardvark bring a helmet, a trombone, and a pizza?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the diaper buy a jetpack?
-Answer: because it heard laughter is the best medicine.
+Question: Why did the drone juggle a helmet, a harmonica, and a scooter?
+Answer: because that's how you get a setup, a callback, and a punchline.
 
-Question: Why did the witty wolf practice yoga?
-Answer: to escape the punchline police.
+Question: Why did the penguin wear a cookie, a umbrella, and a balloon?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Joe Biden host a party?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cactus bring a balloon, a scooter, and a helmet?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the tiny turtle learn to dance?
-Answer: because even animals appreciate a good pun.
+Question: Why did the robot juggle a scooter, a pizza, and a backpack?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Mount Rushmore practice yoga?
-Answer: because nature called and it answered with laughter.
+Question: Why did the violin balance a teapot, a scooter, and a cookie?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the Statue of Liberty visit the library?
-Answer: to make history giggle.
+Question: Why did the unicorn balance a pizza, a slinky, and a teapot?
+Answer: because it heard jokes are better when they come in threes.
 
-Question: Why did the Donald Trump start a podcast?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the pizza bring a pizza, a balloon, and a hat?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the Julius Caesar cook spaghetti?
-Answer: because the aliens told it dad jokes were universal.
+Question: Why did the aardvark balance a slinky, a umbrella, and a trombone?
+Answer: so it could always have a punchline up its sleeve.
 
-Question: Why did the bashful bunny juggle bananas?
-Answer: because it misread the sign that said "no pun intended".
+Question: Why did the cactus bring a pizza, a scooter, and a backpack?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the bathroom mirror take up knitting?
-Answer: because the moon dared it.
+Question: Why did the toaster juggle a harmonica, a trombone, and a cookie?
+Answer: because the invitation said to dress in layers.
 
-Question: Why did the stormy cloud take up knitting?
-Answer: because the GPS told it there was a joke ahead.
+Question: Why did the drone hide a trombone, a harmonica, and a helmet?
+Answer: because it misunderstood the phrase "take something light."
 
-Question: Why did the curious cat write a memoir?
-Answer: because it was feeling a little sheepish.
+Question: Why did the drone wear a teapot, a helmet, and a backpack?
+Answer: because the invitation said to dress in layers.

--- a/data/joke_prompts.txt
+++ b/data/joke_prompts.txt
@@ -1,0 +1,7999 @@
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, slinky, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, paperclip, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, scooter, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, notebook, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, backpack, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, harmonica, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, teapot, harmonica somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, backpack, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, harmonica, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, trombone, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, flashlight, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, teapot, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, umbrella, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, notebook, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, umbrella, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, scooter, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, harmonica, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, helmet, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, teapot, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, notebook, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, garden gnome, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, backpack, yo-yo somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, garden gnome, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, scooter, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, scooter, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, flashlight, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, flashlight, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, cookie, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, garden gnome, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, scooter, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, flashlight, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, snow globe, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, snow globe, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, hat, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, trombone, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, snow globe, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, teapot, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, slinky, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, harmonica, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, teapot, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, notebook, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, snow globe, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, cookie, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, harmonica, yo-yo somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, backpack, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, flashlight, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, teapot, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, umbrella, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, cookie, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, harmonica, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, cookie, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, yo-yo, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, umbrella, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, backpack, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, slinky, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, backpack, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, cookie, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, hat, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, flashlight, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, cookie, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, notebook, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, hat, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, garden gnome, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, umbrella, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, yo-yo, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, umbrella, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, notebook, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, helmet, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, trombone, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, teapot, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, garden gnome, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, cookie, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, notebook, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, umbrella, snow globe somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, garden gnome, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, backpack, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, flashlight, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, teapot, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, backpack, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, harmonica, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, snow globe, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, yo-yo, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, trombone, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, hat, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, cookie, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, trombone, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, trombone, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, umbrella, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, hat, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, paperclip, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, flashlight, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, backpack, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, backpack, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, harmonica, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, garden gnome, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, snow globe, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, scooter, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, notebook, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, helmet, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, snow globe, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, trombone, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, slinky, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, flashlight, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, notebook, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, flashlight, harmonica somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, cookie, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, trombone, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, scooter, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, slinky, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, flashlight, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, balloon, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, paperclip, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, flashlight, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, notebook, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, scooter, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, garden gnome, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, snow globe, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, trombone, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, paperclip, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, backpack, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, helmet, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, backpack, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, flashlight, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, slinky, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, hat, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, harmonica, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, flashlight, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, harmonica, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, hat, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, hat, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, balloon, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, paperclip, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, backpack, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, umbrella, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, notebook, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, cookie, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, balloon, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, helmet, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, balloon, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, trombone, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, cookie, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, trombone, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, yo-yo, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, teapot, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, harmonica, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, hat, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, paperclip, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, hat, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, snow globe, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, garden gnome, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, slinky, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, paperclip, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, slinky, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, flashlight, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, snow globe, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, balloon, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, umbrella, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, yo-yo, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, hat, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, paperclip, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, notebook, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, umbrella, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, harmonica, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, flashlight, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, teapot, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, backpack, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, hat, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, helmet, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, notebook, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, yo-yo, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, hat, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, yo-yo, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, teapot, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, teapot, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, cookie, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, teapot, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, harmonica, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, umbrella, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, harmonica, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, hat, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, umbrella, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, slinky, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, teapot, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, cookie, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, backpack, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, notebook, yo-yo somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, slinky, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, balloon, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, hat, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, balloon, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, slinky, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, paperclip, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, balloon, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, trombone, snow globe somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, balloon, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, paperclip, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, paperclip, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, notebook, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, backpack, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, balloon, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, helmet, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, harmonica, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, scooter, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, helmet, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, cookie, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, trombone, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, backpack, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, cookie, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, scooter, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, garden gnome, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, slinky, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, helmet, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, balloon, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, balloon, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, harmonica, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, yo-yo, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, scooter, harmonica somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, slinky, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, backpack, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, helmet, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, notebook, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, teapot, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, snow globe, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, teapot, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, helmet, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, teapot, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, balloon, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, scooter, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, slinky, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, garden gnome, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, slinky, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, snow globe, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, helmet, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, helmet, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, flashlight, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, balloon, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, helmet, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, teapot, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, paperclip, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, notebook, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, garden gnome, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, backpack, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, notebook, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, paperclip, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, scooter, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, umbrella, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, paperclip, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, helmet, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, garden gnome, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, cookie, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, balloon, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, helmet, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, flashlight, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, backpack, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, scooter, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, snow globe, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, balloon, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, hat, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, snow globe, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, notebook, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, hat, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, paperclip, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, notebook, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, backpack, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, umbrella, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, scooter, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, notebook, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, snow globe, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, hat, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, teapot, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, yo-yo, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, helmet, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, notebook, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, yo-yo, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, helmet, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, helmet, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, snow globe, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, flashlight, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, umbrella, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, slinky, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, backpack, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, slinky, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, trombone, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, balloon, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, harmonica, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, backpack, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, scooter, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, balloon, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, harmonica, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, scooter, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, teapot, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, trombone, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, garden gnome, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, trombone, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, scooter, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, notebook, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, umbrella, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, flashlight, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, cookie, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, slinky, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, scooter, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, hat, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, hat, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, snow globe, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, snow globe, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, flashlight, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, hat, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, harmonica, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, cookie, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, paperclip, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, balloon, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, slinky, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, balloon, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, garden gnome, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, yo-yo, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, yo-yo, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, yo-yo, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, balloon, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, trombone, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, garden gnome, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, umbrella, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, backpack, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, helmet, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, hat, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, harmonica, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, flashlight, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, snow globe, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, backpack, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, snow globe, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, yo-yo, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, scooter, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, paperclip, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, backpack, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, scooter, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, harmonica, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, slinky, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, umbrella, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, flashlight, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, yo-yo, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, teapot, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, backpack, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, helmet, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, helmet, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, teapot, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, umbrella, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, slinky, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, snow globe, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, notebook, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, umbrella, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, hat, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, slinky, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, cookie, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, notebook, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, teapot, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, umbrella, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, helmet, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, cookie, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, paperclip, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, flashlight, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, paperclip, snow globe somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, helmet, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, harmonica, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, trombone, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, yo-yo, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, umbrella, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, helmet, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, backpack, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, teapot, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, cookie, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, cookie, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, umbrella, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, notebook, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, flashlight, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, balloon, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, helmet, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, snow globe, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, backpack, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, scooter, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, backpack, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, notebook, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, harmonica, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, garden gnome, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, slinky, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, harmonica, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, cookie, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, garden gnome, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, yo-yo, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, snow globe, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, balloon, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, garden gnome, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, garden gnome, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, backpack, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, flashlight, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, garden gnome, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, flashlight, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, umbrella, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, notebook, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, slinky, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, paperclip, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, teapot, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, trombone, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, umbrella, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, cookie, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, flashlight, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, scooter, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, backpack, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, notebook, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, notebook, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, cookie, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, scooter, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, teapot, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, hat, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, slinky, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, notebook, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, yo-yo, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, slinky, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, harmonica, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, backpack, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, slinky, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, backpack, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, cookie, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, cookie, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, flashlight, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, slinky, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, notebook, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, balloon, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, flashlight, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, notebook, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, trombone, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, yo-yo, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, hat, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, flashlight, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, scooter, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, helmet, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, cookie, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, garden gnome, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, cookie, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, slinky, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, slinky, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, helmet, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, teapot, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, helmet, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, harmonica, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, helmet, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, garden gnome, yo-yo somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, slinky, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, hat, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, flashlight, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, helmet, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, cookie, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, helmet, snow globe somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, paperclip, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, helmet, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, flashlight, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, helmet, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, flashlight, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, backpack, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, umbrella, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, hat, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, cookie, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, scooter, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, slinky, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, backpack, yo-yo somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, snow globe, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, teapot, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, trombone, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, hat, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, yo-yo, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, harmonica, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, snow globe, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, slinky, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, harmonica, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, scooter, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, harmonica, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, hat, snow globe somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, notebook, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, umbrella, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, flashlight, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, snow globe, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, trombone, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, helmet, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, backpack, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, flashlight, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, hat, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, garden gnome, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, helmet, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, trombone, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, cookie, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, snow globe, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, hat, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, notebook, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, umbrella, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, notebook, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, trombone, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, snow globe, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, cookie, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, teapot, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, harmonica, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, harmonica, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, trombone, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, snow globe, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, garden gnome, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, notebook, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, notebook, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, slinky, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, snow globe, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, trombone, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, helmet, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, trombone, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, helmet, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, backpack, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, snow globe, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, slinky, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, helmet, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, hat, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, snow globe, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, garden gnome, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, yo-yo, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, hat, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, flashlight, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, helmet, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, balloon, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, scooter, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, teapot, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, snow globe, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, trombone, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, cookie, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, yo-yo, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, hat, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, harmonica, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, slinky, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, paperclip, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, balloon, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, flashlight, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, trombone, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, hat, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, trombone, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, cookie, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, flashlight, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, paperclip, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, scooter, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, backpack, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, backpack, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, teapot, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, paperclip, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, scooter, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, garden gnome, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, snow globe, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, hat, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, snow globe, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, scooter, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, balloon, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, trombone, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, garden gnome, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, helmet, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, teapot, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, teapot, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, cookie, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, scooter, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, trombone, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, snow globe, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, hat, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, trombone, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, balloon, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, garden gnome, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, helmet, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, garden gnome, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, yo-yo, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, slinky, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, garden gnome, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, teapot, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, backpack, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, yo-yo, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, harmonica, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, helmet, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, yo-yo, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, teapot, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, backpack, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, cookie, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, balloon, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, teapot, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, yo-yo, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, hat, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, snow globe, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, helmet, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, teapot, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, slinky, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, trombone, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, hat, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, paperclip, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, trombone, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, cookie, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, umbrella, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, flashlight, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, garden gnome, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, umbrella, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, helmet, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, garden gnome, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, harmonica, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, teapot, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, hat, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, teapot, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, garden gnome, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, trombone, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, teapot, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, hat, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, cookie, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, umbrella, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, backpack, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, slinky, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, teapot, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, cookie, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, notebook, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, snow globe, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, paperclip, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, notebook, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, cookie, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, yo-yo, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, paperclip, harmonica somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, backpack, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, paperclip, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, scooter, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, helmet, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, garden gnome, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, flashlight, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, garden gnome, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, balloon, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, balloon, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, backpack, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, yo-yo, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, cookie, yo-yo somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, trombone, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, notebook, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, teapot, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, harmonica, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, garden gnome, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, teapot, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, teapot, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, helmet, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, paperclip, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, balloon, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, balloon, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, backpack, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, paperclip, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, harmonica, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, scooter, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, backpack, harmonica somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, notebook, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, umbrella, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, flashlight, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, slinky, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, paperclip, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, notebook, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, umbrella, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, hat, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, yo-yo, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, helmet, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, paperclip, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, garden gnome, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, garden gnome, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, harmonica, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, cookie, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, notebook, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, snow globe, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, notebook, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, cookie, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, slinky, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, balloon, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, hat, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, paperclip, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, harmonica, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, hat, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, notebook, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, slinky, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, snow globe, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, trombone, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, paperclip, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, harmonica, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, backpack, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, garden gnome, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, snow globe, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, teapot, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, harmonica, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, harmonica, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, teapot, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, slinky, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, yo-yo, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, trombone, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, paperclip, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, slinky, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, paperclip, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, garden gnome, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, trombone, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, cookie, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, backpack, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, notebook, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, backpack, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, flashlight, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, backpack, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, backpack, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, slinky, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, paperclip, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, helmet, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, hat, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, scooter, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, garden gnome, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, hat, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, backpack, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, flashlight, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, garden gnome, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, cookie, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, balloon, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, garden gnome, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, helmet, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, helmet, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, harmonica, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, notebook, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, notebook, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, flashlight, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, backpack, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, yo-yo, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, paperclip, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, notebook, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, paperclip, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, garden gnome, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, scooter, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, paperclip, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, umbrella, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, flashlight, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, cookie, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, flashlight, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, umbrella, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, slinky, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, hat, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, harmonica, hat somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, garden gnome, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, backpack, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, flashlight, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, cookie, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, yo-yo, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, notebook, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, teapot, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, hat, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, paperclip, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, backpack, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, paperclip, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, helmet, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, snow globe, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, umbrella, harmonica somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, helmet, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, snow globe, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, scooter, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, cookie, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, slinky, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, slinky, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, umbrella, balloon somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, trombone, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, garden gnome, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, garden gnome, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, hat, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, slinky, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, notebook, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, balloon, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, balloon, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, slinky, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, yo-yo, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, cookie, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, flashlight, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, helmet, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, hat, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, harmonica, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, paperclip, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, paperclip, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, paperclip, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, teapot, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, cookie, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, scooter, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, yo-yo, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, paperclip, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, cookie, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, backpack, paperclip somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, cookie, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, backpack, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, paperclip, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, cookie, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, snow globe, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, flashlight, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, scooter, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, yo-yo, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, flashlight, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, yo-yo, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, balloon, notebook somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, scooter, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, slinky, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, balloon, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, notebook, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, notebook, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, garden gnome, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, helmet, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, backpack, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, balloon, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, snow globe, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, hat, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, flashlight, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, paperclip, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, harmonica, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, garden gnome, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, notebook, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, scooter, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, teapot, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, scooter, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, umbrella, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, umbrella, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, cookie, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, notebook, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, umbrella, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, hat, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, snow globe, harmonica somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, yo-yo, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, helmet, notebook somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, backpack, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, cookie, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, teapot, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, garden gnome, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, trombone, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, teapot, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, hat, snow globe somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, harmonica, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, hat, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, backpack, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, paperclip, yo-yo somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, yo-yo, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, backpack, flashlight somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, flashlight, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, snow globe, scooter somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, scooter, snow globe somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, teapot, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, slinky, balloon somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, paperclip, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, notebook, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, teapot, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, teapot, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, harmonica, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, yo-yo, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, trombone, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, notebook, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, umbrella, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, hat, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, harmonica, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, helmet, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, yo-yo, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, slinky, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a zebra.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, teapot, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, teapot, umbrella somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, balloon, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, harmonica, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, harmonica, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, paperclip, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, yo-yo, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, yo-yo, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, slinky, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, paperclip, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, notebook, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, harmonica, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, teapot, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, paperclip, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, hat, snow globe somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, backpack, balloon somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, scooter, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, harmonica, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, notebook, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, paperclip, cookie somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, notebook, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, balloon, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, garden gnome, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, snow globe, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, flashlight, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, umbrella, yo-yo somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, helmet, paperclip somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, cookie, yo-yo somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, teapot, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, yo-yo, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, scooter, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, balloon, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, teapot, garden gnome somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, harmonica, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, notebook, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, slinky, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, yo-yo, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, paperclip, trombone somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, teapot, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, yo-yo, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, balloon, notebook somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, paperclip, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, cookie, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, harmonica, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, notebook, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, notebook, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, cookie, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, notebook, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, flashlight, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, cookie, slinky somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, snow globe, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, harmonica, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, harmonica, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, backpack, teapot somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, garden gnome, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, cookie, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, scooter, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, backpack, snow globe somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, trombone, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, scooter, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, paperclip, hat somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, trombone, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, flashlight, balloon somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, backpack, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, teapot, slinky somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, snow globe, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, yo-yo, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, yo-yo, trombone somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a penguin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, scooter, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, balloon, cookie somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, slinky, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, backpack, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, trombone, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, notebook, helmet somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects cookie, yo-yo, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, teapot, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, scooter, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, teapot, backpack somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, snow globe, slinky somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, trombone, slinky somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, snow globe, garden gnome somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, notebook, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, snow globe, trombone somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, paperclip, flashlight somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects snow globe, flashlight, backpack somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, balloon, garden gnome somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a marshmallow.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, harmonica, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects harmonica, garden gnome, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cactus.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, hat, yo-yo somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, scooter, cookie somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, trombone, hat somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, notebook, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a astronaut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, helmet, umbrella somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, snow globe, umbrella somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, umbrella, hat somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a submarine.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, slinky, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, harmonica, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, helmet, teapot somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, backpack, flashlight somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, balloon, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, hat, paperclip somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a piano.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, trombone, teapot somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, harmonica, helmet somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, notebook, cookie somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, paperclip, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a turtle.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, snow globe, flashlight somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects helmet, notebook, scooter somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, snow globe, umbrella somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a banana.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects teapot, garden gnome, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects notebook, teapot, harmonica somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a toaster.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects flashlight, cookie, teapot somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a robot.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, yo-yo, helmet somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a pizza.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, helmet, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects trombone, paperclip, garden gnome somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a drone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects backpack, harmonica, trombone somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a cloud.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects scooter, paperclip, backpack somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, slinky, backpack somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a aardvark.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects umbrella, slinky, yo-yo somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a violin.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects yo-yo, teapot, helmet somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a donut.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects paperclip, yo-yo, scooter somewhere in the setup or punchline.
+Twist expectations using an unexpected callback.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a unicorn.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects hat, slinky, notebook somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects balloon, notebook, harmonica somewhere in the setup or punchline.
+Twist expectations using a playful pun.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a saxophone.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects slinky, notebook, scooter somewhere in the setup or punchline.
+Twist expectations using the rule of three.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>
+
+Write a clean, family-friendly dad joke about a lawnmower.
+Brainstorm a few assumptions and pick the most surprising angle.
+Work in the objects garden gnome, harmonica, paperclip somewhere in the setup or punchline.
+Twist expectations using misdirection.
+Return the joke on exactly two lines labeled like:
+Question: <setup>
+Answer: <punchline>

--- a/lib/generatePrompt.mjs
+++ b/lib/generatePrompt.mjs
@@ -1,0 +1,47 @@
+import { randomInt } from 'crypto';
+
+const topics = [
+  'aardvark', 'astronaut', 'toaster', 'penguin', 'cloud', 'robot', 'cactus',
+  'zebra', 'banana', 'violin', 'turtle', 'drone', 'unicorn', 'pizza',
+  'submarine', 'lawnmower', 'donut', 'saxophone', 'marshmallow', 'piano'
+];
+
+const objects = [
+  'hat', 'scooter', 'trombone', 'slinky', 'teapot', 'balloon', 'helmet',
+  'backpack', 'harmonica', 'umbrella', 'cookie', 'flashlight', 'notebook',
+  'yo-yo', 'snow globe', 'paperclip', 'garden gnome'
+];
+
+const devices = [
+  'misdirection',
+  'the rule of three',
+  'a playful pun',
+  'an unexpected callback'
+];
+
+function pick(arr) {
+  return arr[randomInt(arr.length)];
+}
+
+function pickUnique(arr, count) {
+  const chosen = new Set();
+  while (chosen.size < count) {
+    chosen.add(pick(arr));
+  }
+  return Array.from(chosen);
+}
+
+export function generatePrompt() {
+  const topic = pick(topics);
+  const extras = pickUnique(objects, 3);
+  const device = pick(devices);
+  return [
+    `Write a clean, family-friendly dad joke about a ${topic}.`,
+    'Brainstorm a few assumptions and pick the most surprising angle.',
+    `Work in the objects ${extras.join(', ')} somewhere in the setup or punchline.`,
+    `Twist expectations using ${device}.`,
+    'Return the joke on exactly two lines labeled like:',
+    'Question: <setup>',
+    'Answer: <punchline>'
+  ].join('\n');
+}

--- a/pages/api/openai.js
+++ b/pages/api/openai.js
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 import fs from 'fs';
 import path from 'path';
+import { generatePrompt } from '../../lib/generatePrompt.mjs';
 
 /*
  * When running locally without a valid API key (for example, during development
@@ -60,25 +61,11 @@ export default async function handler(req, res) {
     res.setHeader('Connection', 'keep-alive');
 
     try {
-        // Build a prompt asking for a dad joke about a random topic and instructing
-        // the assistant to return it in a two-line format with "Question:" and "Answer:" prefixes.
-        // Build a prompt asking the model to first choose a completely random and unexpected topic
-        // and then craft a dad joke about it. We explicitly instruct the model to vary the
-        // subject each time to encourage diversity. The joke should be returned on two lines
-        // using the "Question:" and "Answer:" prefixes so the client can split them easily.
-        // Construct a prompt that strongly encourages the model to pick a unique,
-        // unpredictable topic on its own rather than echoing the user's input. We ask
-        // for a family‑friendly dad joke about a random subject and instruct the
-        // model to return the result using Question: and Answer: labels on separate
-        // lines. By emphasising randomness and novelty in the topic we increase the
-        // likelihood that the model varies its output each call.
-        const prompt = [
-          'Pick a truly random, creative and unpredictable topic. This could be an unusual animal, a quirky situation, or an imaginary scenario – the more surprising the better.',
-          'Use this unique topic to craft a witty, family‑friendly dad joke.',
-          'Return your response on two lines exactly in the following format:',
-          'Question: <the setup>',
-          'Answer: <the punchline>'
-        ].join('\n');
+        // Generate a fresh prompt that picks random topics and comedic devices
+        // while keeping the wording clean and family friendly. The response
+        // must be two lines labelled "Question:" and "Answer:" so the client
+        // can easily parse it.
+        const prompt = generatePrompt();
 
         const jokeResponse = await openai.responses.create({
             model: "gpt-4o",

--- a/scripts/generate-prompt.mjs
+++ b/scripts/generate-prompt.mjs
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+import { generatePrompt } from '../lib/generatePrompt.mjs';
+
+const count = parseInt(process.argv[2], 10) || 1000;
+const outPath = path.join(process.cwd(), 'data', 'joke_prompts.txt');
+
+const prompts = Array.from({ length: count }, () => generatePrompt());
+fs.writeFileSync(outPath, prompts.join('\n\n'));
+console.log(`Saved ${count} prompts to ${outPath}`);


### PR DESCRIPTION
## Summary
- generate dad joke prompts with random topics, objects and devices
- use a fresh prompt for every OpenAI request
- add utility script that produces a list of prompts for bulk joke generation

## Testing
- `npm run lint`
- `node scripts/generate-prompt.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68974f3d8d508328a98ba048341ce842