### PR TITLE
feat: add edgy comedian-style joke prompts

### DIFF
--- a/data/dad_jokes.txt
+++ b/data/dad_jokes.txt
@@ -1,29 +1,29 @@
-Question: Why did the astronaut pack a harmonica for the mission?
-Answer: He heard space was perfect for a little space jam.
+Question: Why did the accountant bring hot sauce to the audit?
+Answer: Bernie Mac said if you're gonna feel the burn, make it taste good.
 
-Question: Why did the toaster join a band with a drum and a tambourine?
-Answer: It already knew how to pop on cue.
+Question: Why did the dating app match a plumber with a lawyer?
+Answer: Chris Rock figured love always needs someone to fix leaks and someone to argue about who caused them.
 
-Question: Why did the penguin bring a backpack to the beach?
-Answer: It wanted to keep its snacks on ice.
+Question: Why did the taxicab carry a selfie stick on night shifts?
+Answer: Dave Chappelle wanted proof that the meter wasn't the only thing running.
 
-Question: Why did the robot carry a notebook to the party?
-Answer: So it could take byte-sized notes.
+Question: Why did the yoga teacher wear steel-toed boots to class?
+Answer: Ali Wong said enlightenment doesn't cover stubbed toes.
 
-Question: Why did the cactus wear a fancy hat and sunglasses?
-Answer: It liked to look sharp while avoiding a burn.
+Question: Why did the reality TV star pack a library card for the reunion show?
+Answer: Wanda Sykes dared them to find drama in the Dewey Decimal System.
 
-Question: Why did the pizza ride a scooter to the talent show?
-Answer: It wanted to deliver a cheesy performance on the go.
+Question: Why did the midlife crisis buy a skateboard and a helmet?
+Answer: Joan Rivers swore you're never too old to break something expensive.
 
-Question: Why did the submarine keep a flashlight in the galley?
-Answer: So the cook could make light snacks.
+Question: Why did the group chat hire a referee?
+Answer: Richard Pryor knew someone was about to get flagged for emoji misuse.
 
-Question: Why did the lawnmower practice the yo-yo?
-Answer: It liked to unwind before cutting loose.
+Question: Why did the conspiracy theorist install skylights in the basement?
+Answer: Kevin Hart said if the truth is out there, let it pay rent.
 
-Question: Why did the donut bring a notebook to class?
-Answer: It didn't want any holes in its homework.
+Question: Why did the stand-up comic bring a flask to the gym?
+Answer: Bernie Mac said even workouts need a punchline.
 
-Question: Why did the turtle bring a harmonica on the hike?
-Answer: It wanted a little shell-ebration.
+Question: Why did the remote worker wear a tuxedo over pajama pants?
+Answer: Chris Rock told him business on top and lies on the bottom is still a dress code.

--- a/lib/generatePrompt.mjs
+++ b/lib/generatePrompt.mjs
@@ -1,22 +1,68 @@
 import { randomInt } from 'crypto';
 
 const topics = [
-  'aardvark', 'astronaut', 'toaster', 'penguin', 'cloud', 'robot', 'cactus',
-  'zebra', 'banana', 'violin', 'turtle', 'drone', 'unicorn', 'pizza',
-  'submarine', 'lawnmower', 'donut', 'saxophone', 'marshmallow', 'piano'
+  'tax season',
+  'in-laws',
+  'dating apps',
+  'reality TV',
+  'midlife crisis',
+  'office politics',
+  'bad Wi-Fi',
+  'grocery prices',
+  'group chats',
+  'cryptocurrency',
+  'conspiracy theories',
+  'hangovers',
+  'DIY disasters',
+  'meetings that could be emails',
+  'small talk at weddings'
 ];
 
 const objects = [
-  'hat', 'scooter', 'trombone', 'slinky', 'teapot', 'balloon', 'helmet',
-  'backpack', 'harmonica', 'umbrella', 'cookie', 'flashlight', 'notebook',
-  'yo-yo', 'snow globe', 'paperclip', 'garden gnome'
+  'cheap wine',
+  'air fryer',
+  'velcro sneakers',
+  'karaoke machine',
+  'flask',
+  'selfie stick',
+  'fidget spinner',
+  'fake ID',
+  'stress ball',
+  'scented candle',
+  'rubber chicken',
+  'hot sauce',
+  'skateboard',
+  'tattoo',
+  'smartphone',
+  'pajama pants',
+  'boombox',
+  'skylight'
 ];
 
 const devices = [
-  'misdirection',
+  'a sarcastic tag',
   'the rule of three',
-  'a playful pun',
-  'an unexpected callback'
+  'a spicy callback',
+  'an exaggerated comparison'
+];
+
+const comedians = [
+  'Bernie Mac',
+  'Dave Chappelle',
+  'Ali Wong',
+  'Chris Rock',
+  'Joan Rivers',
+  'Richard Pryor',
+  'Wanda Sykes'
+];
+
+const templates = [
+  ({ topic, extras, device, comedian }) =>
+    `Channel ${comedian} and craft a quick, edgy joke about ${topic}. Work in ${extras[0]} and ${extras[1]}. Flip expectations with ${device}. Keep it playful and PG-13.`,
+  ({ topic, extras, device, comedian }) =>
+    `In the voice of ${comedian}, write a bold one-liner on ${topic} that sneaks in ${extras.join(', ')}. Finish with ${device} for the punch. Keep it playful and PG-13.`,
+  ({ topic, extras, device, comedian }) =>
+    `Sound like ${comedian} doing a short roast about ${topic}. Mention ${extras[2]} somewhere and hit the crowd with ${device}. Keep it playful and PG-13.`
 ];
 
 function pick(arr) {
@@ -35,11 +81,10 @@ export function generatePrompt() {
   const topic = pick(topics);
   const extras = pickUnique(objects, 3);
   const device = pick(devices);
+  const comedian = pick(comedians);
+  const template = pick(templates);
   return [
-    `Write a clean, family-friendly dad joke about a ${topic}.`,
-    'Brainstorm a few assumptions and pick the most surprising angle.',
-    `Work in the objects ${extras.join(', ')} somewhere in the setup or punchline.`,
-    `Twist expectations using ${device}.`,
+    template({ topic, extras, device, comedian }),
     'Return the joke on exactly two lines labeled like:',
     'Question: <setup>',
     'Answer: <punchline>'


### PR DESCRIPTION
## Summary
- broaden joke prompt generator with edgy topics and random comedian voices
- refresh backup jokes to match the new comedic style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68976eb474148328b6159daa88de2457