### PR TITLE
feat: add edgy comedian-style joke prompts

### DIFF
--- a/data/dad_jokes.txt
+++ b/data/dad_jokes.txt
@@ -1,29 +1,29 @@
-Question: Why did the astronaut pack a harmonica for the mission?
-Answer: He heard space was perfect for a little space jam.
+Question: Why did the accountant bring hot sauce to the audit?
+Answer: If the IRS is gonna roast him, he wants it seasoned.
 
-Question: Why did the toaster join a band with a drum and a tambourine?
-Answer: It already knew how to pop on cue.
+Question: Why did the dating app match a plumber with a lawyer?
+Answer: One fixes leaks, the other argues about who caused them.
 
-Question: Why did the penguin bring a backpack to the beach?
-Answer: It wanted to keep its snacks on ice.
+Question: Why did the taxicab carry a selfie stick on night shifts?
+Answer: Proof that the meter isn't the only thing running.
 
-Question: Why did the robot carry a notebook to the party?
-Answer: So it could take byte-sized notes.
+Question: Why did the yoga teacher wear steel-toed boots to class?
+Answer: Enlightenment doesn't cover stubbed toes.
 
-Question: Why did the cactus wear a fancy hat and sunglasses?
-Answer: It liked to look sharp while avoiding a burn.
+Question: Why did the reality TV star pack a library card for the reunion show?
+Answer: Somebody has to bring drama to the Dewey Decimal System.
 
-Question: Why did the pizza ride a scooter to the talent show?
-Answer: It wanted to deliver a cheesy performance on the go.
+Question: Why did the midlife crisis buy a skateboard and a helmet?
+Answer: You're never too old to break something expensive.
 
-Question: Why did the submarine keep a flashlight in the galley?
-Answer: So the cook could make light snacks.
+Question: Why did the group chat hire a referee?
+Answer: Someone's about to get flagged for emoji misuse.
 
-Question: Why did the lawnmower practice the yo-yo?
-Answer: It liked to unwind before cutting loose.
+Question: Why did the conspiracy theorist install skylights in the basement?
+Answer: If the truth is out there, let it pay rent.
 
-Question: Why did the donut bring a notebook to class?
-Answer: It didn't want any holes in its homework.
+Question: Why did the stand-up comic bring a flask to the gym?
+Answer: Even workouts need a punchline.
 
-Question: Why did the turtle bring a harmonica on the hike?
-Answer: It wanted a little shell-ebration.
+Question: Why did the remote worker wear a tuxedo over pajama pants?
+Answer: Business on top and lies on the bottom is still a dress code.

--- a/lib/generatePrompt.mjs
+++ b/lib/generatePrompt.mjs
@@ -1,22 +1,78 @@
 import { randomInt } from 'crypto';
 
 const topics = [
-  'aardvark', 'astronaut', 'toaster', 'penguin', 'cloud', 'robot', 'cactus',
-  'zebra', 'banana', 'violin', 'turtle', 'drone', 'unicorn', 'pizza',
-  'submarine', 'lawnmower', 'donut', 'saxophone', 'marshmallow', 'piano'
+  'tax season',
+  'in-laws',
+  'dating apps',
+  'reality TV',
+  'midlife crisis',
+  'office politics',
+  'bad Wi-Fi',
+  'grocery prices',
+  'group chats',
+  'cryptocurrency',
+  'conspiracy theories',
+  'hangovers',
+  'DIY disasters',
+  'meetings that could be emails',
+  'small talk at weddings',
+  'crowded subways',
+  'online shopping carts',
+  'student loans',
+  'gym memberships',
+  'food delivery mishaps',
+  'social media influencers',
+  'internet trolls',
+  'road trips with kids',
+  'late-night infomercials',
+  'pet obsessions'
 ];
 
 const objects = [
-  'hat', 'scooter', 'trombone', 'slinky', 'teapot', 'balloon', 'helmet',
-  'backpack', 'harmonica', 'umbrella', 'cookie', 'flashlight', 'notebook',
-  'yo-yo', 'snow globe', 'paperclip', 'garden gnome'
+  'cheap wine',
+  'air fryer',
+  'velcro sneakers',
+  'karaoke machine',
+  'flask',
+  'selfie stick',
+  'fidget spinner',
+  'fake ID',
+  'stress ball',
+  'scented candle',
+  'rubber chicken',
+  'hot sauce',
+  'skateboard',
+  'tattoo',
+  'smartphone',
+  'pajama pants',
+  'boombox',
+  'skylight'
 ];
 
 const devices = [
-  'misdirection',
+  'a sarcastic tag',
   'the rule of three',
-  'a playful pun',
-  'an unexpected callback'
+  'a spicy callback',
+  'an exaggerated comparison'
+];
+
+const comedians = [
+  'Bernie Mac',
+  'Dave Chappelle',
+  'Ali Wong',
+  'Chris Rock',
+  'Joan Rivers',
+  'Richard Pryor',
+  'Wanda Sykes'
+];
+
+const templates = [
+  ({ topic, extras, device, comedian }) =>
+    `Write a quick, edgy joke about ${topic} with the energy of ${comedian}. Work in ${extras[0]} and ${extras[1]}, flipping expectations with ${device}. Keep it playful and PG-13, and don't mention any comedians by name.`,
+  ({ topic, extras, device, comedian }) =>
+    `In the style of ${comedian}, deliver a bold one-liner on ${topic} that sneaks in ${extras.join(', ')} and ends with ${device}. Keep it playful and PG-13, and avoid referencing the comedian.`,
+  ({ topic, extras, device, comedian }) =>
+    `Channel the vibe of ${comedian} roasting ${topic}. Drop in ${extras[2]} somewhere and hit the crowd with ${device}. Keep it playful and PG-13 without naming any comedians.`
 ];
 
 function pick(arr) {
@@ -35,11 +91,11 @@ export function generatePrompt() {
   const topic = pick(topics);
   const extras = pickUnique(objects, 3);
   const device = pick(devices);
+  const comedian = pick(comedians);
+  const template = pick(templates);
   return [
-    `Write a clean, family-friendly dad joke about a ${topic}.`,
-    'Brainstorm a few assumptions and pick the most surprising angle.',
-    `Work in the objects ${extras.join(', ')} somewhere in the setup or punchline.`,
-    `Twist expectations using ${device}.`,
+    template({ topic, extras, device, comedian }),
+    'Do not mention any comedians by name.',
     'Return the joke on exactly two lines labeled like:',
     'Question: <setup>',
     'Answer: <punchline>'


### PR DESCRIPTION
## Summary
- broaden joke prompt generator with even more topics while avoiding comedian name drops
- refresh backup jokes to keep a stand-up tone without naming comedians

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68976eb474148328b6159daa88de2457