### PR TITLE
Stream jokes token-by-token in UI

### DIFF
--- a/lib/generatePrompt.mjs
+++ b/lib/generatePrompt.mjs
@@ -95,6 +95,7 @@ export function generatePrompt() {
   const template = pick(templates);
   return [
     template({ topic, extras, device, comedian }),
+    'Avoid using special characters or symbols; respond with plain text only.',
     'Do not mention any comedians by name.',
     'Return the joke on exactly two lines labeled like:',
     'Question: <setup>',


### PR DESCRIPTION
## Summary
- Stream SSE tokens live into question and answer fields on the client
- In OpenAI prompt generator, keep output format at end and move plain-text instruction earlier for clarity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b1a85ad08328b29ea08c6dab9d43