### PR TITLE
feat: add new joke request button

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -22,6 +22,26 @@ class OpenAIData extends React.Component {
   }
 
   componentDidMount() {
+    // Load the initial joke when the component mounts
+    this.fetchJoke();
+  }
+
+  fetchJoke = () => {
+    // Close any existing connection before opening a new one
+    if (this.eventSource) {
+      this.eventSource.close();
+    }
+    // Reset state so the spinner is shown while loading
+    this.setState({
+      error: null,
+      isLoaded: false,
+      question: '',
+      answer: '',
+      questionTokens: [],
+      answerTokens: [],
+      pendingQuestion: ''
+    });
+
     // Establish an EventSource connection to receive SSEs from the backend
     this.eventSource = new EventSource("/api/openai");
     // Buffer for the raw streamed joke so we can incrementally parse the
@@ -81,6 +101,9 @@ class OpenAIData extends React.Component {
             ))}
           </p>
         )}
+        <button className={styles.newJokeButton} onClick={this.fetchJoke}>
+          New Joke
+        </button>
       </div>
     );
   }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -231,6 +231,24 @@
   margin-top: 0.5rem;
 }
 
+.newJokeButton {
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background-color: var(--color-primary);
+  color: var(--color-text);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.newJokeButton:hover {
+  background-color: #0059c1;
+  transform: translateY(-2px);
+}
+
 /* Simple fade-in utility for question and answer text */
 .fadeIn {
   opacity: 0;


### PR DESCRIPTION
## Summary
- add reusable `fetchJoke` function to reload jokes over SSE
- add sleek "New Joke" button to homepage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ed8adac88328871190c92a93e7a7