### PR TITLE
feat: add new joke request button

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -231,6 +231,27 @@
   margin-top: 0.5rem;
 }
 
+.newJokeButton {
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background-color: var(--color-surface-dark);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-dark);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  opacity: 0;
+  animation: fadeIn 0.3s ease-in forwards;
+}
+
+.newJokeButton:hover {
+  background-color: var(--color-border-dark);
+  border-color: var(--color-primary);
+  transform: translateY(-2px);
+}
+
 /* Simple fade-in utility for question and answer text */
 .fadeIn {
   opacity: 0;


### PR DESCRIPTION
## Summary
- add reusable `fetchJoke` function to reload jokes over SSE
- add sleek "New Joke" button to homepage
- delay showing button until the current joke is fully loaded and style it for the dark theme
- fade in the button when it appears

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ed8adac88328871190c92a93e7a7