### PR TITLE
Fallback to local jokes when OpenAI fails

### DIFF
--- a/__tests__/api/openai.test.js
+++ b/__tests__/api/openai.test.js
@@ -1,16 +1,63 @@
-import handler from '../../pages/api/openai';
+import fs from 'fs';
+import path from 'path';
 import { createMocks } from 'node-mocks-http';
 
 describe('GET /api/openai', () => {
-  beforeAll(() => {
-    process.env.MOCK_OPENAI = 'true';
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.MOCK_OPENAI;
+    delete process.env.API_KEY;
+    delete process.env.OPENAI_TIMEOUT_MS;
   });
 
   it('streams joke data and ends properly', async () => {
+    process.env.MOCK_OPENAI = 'true';
+    const handler = require('../../pages/api/openai').default;
     const { req, res } = createMocks({ method: 'GET' });
     await handler(req, res);
     const data = res._getData();
     expect(res.getHeader('Content-Type')).toBe('text/event-stream');
+    expect(data).toContain('[DONE]');
+  });
+
+  it('falls back to file joke when OpenAI errors', async () => {
+    process.env.API_KEY = 'test';
+    jest.doMock('openai', () => {
+      return jest.fn().mockImplementation(() => ({
+        responses: {
+          create: jest.fn().mockRejectedValue(new Error('boom'))
+        }
+      }));
+    });
+    const handler = require('../../pages/api/openai').default;
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req, res);
+    const data = res._getData();
+    const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt');
+    const jokes = fs.readFileSync(jokesPath, 'utf-8').split('\n\n').filter(Boolean);
+    const found = jokes.some(j => data.includes(j));
+    expect(found).toBe(true);
+    expect(data).toContain('[DONE]');
+  });
+
+  it('falls back to file joke when request times out', async () => {
+    process.env.API_KEY = 'test';
+    process.env.OPENAI_TIMEOUT_MS = '10';
+    jest.doMock('openai', () => {
+      return jest.fn().mockImplementation(() => ({
+        responses: {
+          create: jest.fn(() => new Promise(() => {}))
+        }
+      }));
+    });
+    const handler = require('../../pages/api/openai').default;
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req, res);
+    const data = res._getData();
+    const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt');
+    const jokes = fs.readFileSync(jokesPath, 'utf-8').split('\n\n').filter(Boolean);
+    const found = jokes.some(j => data.includes(j));
+    expect(found).toBe(true);
     expect(data).toContain('[DONE]');
   });
 });


### PR DESCRIPTION
## Summary
- stream jokes from OpenAI with a 3s timeout
- fall back to a local dad joke on API error or timeout
- retry on the client with local jokes when SSE errors or times out
- cover fallback logic with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897f8e5508883288118533863a92ce3