### PR TITLE
Refine dad joke prompt for single-topic pun style

### DIFF
--- a/lib/generatePrompt.mjs
+++ b/lib/generatePrompt.mjs
@@ -28,75 +28,56 @@ const topics = [
   'pet obsessions'
 ];
 
-const objects = [
-  'cheap wine',
-  'air fryer',
-  'velcro sneakers',
-  'karaoke machine',
-  'flask',
-  'selfie stick',
-  'fidget spinner',
-  'fake ID',
-  'stress ball',
-  'scented candle',
-  'rubber chicken',
-  'hot sauce',
-  'skateboard',
-  'tattoo',
-  'smartphone',
-  'pajama pants',
-  'boombox',
-  'skylight'
+const angles = [
+  'an observational twist on everyday life',
+  'a clever play on words that sneaks up on the audience',
+  'a gentle self-own that keeps things humble',
+  'a comforting family-friendly wink',
+  'a classic setup that flips expectations at the end',
+  'a warm exaggeration that still feels relatable'
 ];
 
 const devices = [
-  'a sarcastic tag',
-  'the rule of three',
-  'a spicy callback',
-  'an exaggerated comparison'
+  'a callback to the setup',
+  'a quick tag that leans into wordplay',
+  'a playful exaggerated comparison',
+  'a lighthearted misdirection'
 ];
 
 const comedians = [
+  'Jerry Seinfeld',
   'Bernie Mac',
   'Dave Chappelle',
   'Ali Wong',
   'Chris Rock',
-  'Joan Rivers',
-  'Richard Pryor',
+  'Jim Gaffigan',
   'Wanda Sykes'
 ];
 
 const templates = [
-  ({ topic, extras, device, comedian }) =>
-    `Roast ${topic} with a groan-worthy dad joke in the spirit of ${comedian}. Work in ${extras[0]} and ${extras[1]} and use ${device} to link the punchline back to the setup. Keep it playful and PG-13 without naming any comedians.`,
-  ({ topic, extras, device, comedian }) =>
-    `In the style of ${comedian}, craft a roasting dad joke about ${topic} that sneaks in ${extras.join(', ')} and lands with ${device}. Make sure the punchline clearly connects to the setup. Keep it PG-13 and skip naming the comedian.`,
-  ({ topic, extras, device, comedian }) =>
-    `Channel the energy of ${comedian} to roast ${topic} with a punny dad joke. Slip in ${extras[2]} and finish with ${device} that ties back to the setup. Keep it playful and PG-13 without mentioning any comedians.`
+  ({ topic, angle, device, comedian }) =>
+    `In the spirit of ${comedian}, write a groan-worthy punny dad joke about ${topic}. Let ${angle} guide the setup and use ${device} so the punchline circles back to where it started. Keep it playful, PG-13, and avoid naming any comedians.`,
+  ({ topic, angle, device, comedian }) =>
+    `Channel the everyday charm of ${comedian} to craft a pun-forward dad joke focused on ${topic}. Lean on ${angle}, rely on ${device} to connect the payoff to the setup, and keep the humor warm rather than roasty.`,
+  ({ topic, angle, device, comedian }) =>
+    `Make a classic dad joke about ${topic} that would make ${comedian} proud—groan-inducing, pun-heavy, and full of heart. Work in ${angle} and finish with ${device} to keep the whole thing tied together. Keep it PG-13 and skip naming the comedian.`
 ];
 
 function pick(arr) {
   return arr[randomInt(arr.length)];
 }
 
-function pickUnique(arr, count) {
-  const chosen = new Set();
-  while (chosen.size < count) {
-    chosen.add(pick(arr));
-  }
-  return Array.from(chosen);
-}
-
 export function generatePrompt() {
   const topic = pick(topics);
-  const extras = pickUnique(objects, 3);
+  const angle = pick(angles);
   const device = pick(devices);
   const comedian = pick(comedians);
   const template = pick(templates);
   return [
-    template({ topic, extras, device, comedian }),
+    template({ topic, angle, device, comedian }),
     'Avoid using special characters or symbols; respond with plain text only.',
-    'Make the joke roast the topic in a classic dad-joke style and ensure the punchline clearly relates to the setup.',
+    'Keep the humor pun-forward, groan-inducing, and good-natured rather than a roast.',
+    'Make sure the punchline clearly relates back to the setup and stays focused on that single topic.',
     'Do not mention any comedians by name.',
     'Return the joke on exactly two lines labeled like:',
     'Question: <setup>',


### PR DESCRIPTION
## Summary
- rework the dad-joke prompt templates to focus on a single topic with warm, pun-forward humor inspired by classic stand-up voices
- replace the old multi-topic extras with observational angles and updated comedic devices for varied yet cohesive jokes
- refresh the shared guidance to keep the output groan-inducing, good-natured, and clearly tied back to the setup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8bea9be6c8328ae88dba096f0e7b5