### PR TITLE
Add configurable daily dad joke mode with historical context

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,38 @@ You can start editing the page by modifying `pages/index.js`. The page auto-upda
 
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
 
+## Groan ratings & free storage option
+
+The home page now lets visitors rate each joke on a five groan scale. Ratings are persisted through the `/api/ratings` route, which is designed to run against [Vercel KV](https://vercel.com/docs/storage/vercel-kv) — Vercel's serverless Redis offering that includes a generous free tier and works seamlessly on Vercel-hosted deployments.
+
+1. In the Vercel dashboard, add a KV store to your project (the free hobby plan is sufficient for a handful of ratings).
+2. Copy the generated credentials and expose them to the app as environment variables:
+
+   ```bash
+   KV_URL=<value>
+   KV_REST_API_URL=<value>
+   KV_REST_API_TOKEN=<value>
+   KV_REST_API_READ_ONLY_TOKEN=<value>
+   ```
+
+3. Redeploy. The `/api/ratings` route will start reading/writing groan counts per joke. When these variables are absent (for example during local development), the route falls back to an in-memory store so the UI can still be exercised.
+
+## Joke of the day mode
+
+If you want to track a single joke over the course of the day, switch the homepage into **Joke of the Day** mode using the toggle above the joke. When active the app:
+
+- Calls `/api/daily-joke`, which fetches "On this day" facts from Wikipedia's public REST API.
+- Generates a dad joke that references the selected historical event and caches it in Vercel KV (or an in-memory fallback) so everyone sees the same joke for that date.
+- Surfaces the historical context, including a summary and source link, under the joke so you know why the gag is timely.
+
+To make the daily joke the default view on load, set an environment variable before building the app:
+
+```bash
+NEXT_PUBLIC_DEFAULT_JOKE_MODE=daily
+```
+
+With the variable set, visitors land on the date-aware daily joke but can still switch back to the live streaming mode at any time.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/lib/generatePrompt.mjs
+++ b/lib/generatePrompt.mjs
@@ -67,7 +67,35 @@ function pick(arr) {
   return arr[randomInt(arr.length)];
 }
 
-export function generatePrompt() {
+function buildDailyPrompt(event) {
+  const {
+    year,
+    text,
+    title,
+    summary,
+    source
+  } = event;
+  const description = summary || text || title;
+  const sourceLine = source ? `Use this reference for context: ${source}.` : '';
+  return [
+    'Craft a dad joke that feels timely for today. Use the details below as inspiration and weave them into the setup or punchline in a playful way:',
+    `Event: ${description}`,
+    year ? `Happened in: ${year}` : '',
+    sourceLine,
+    'Keep the humor groan-worthy but warm-hearted, and make sure the joke makes it clear why the event or date matters.',
+    'Avoid using special characters or symbols; respond with plain text only.',
+    'Return the joke on exactly two lines labeled like:',
+    'Question: <setup>',
+    'Answer: <punchline>'
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function generatePrompt(options = {}) {
+  if (options.mode === 'daily' && options.event) {
+    return buildDailyPrompt(options.event);
+  }
   const topic = pick(topics);
   const angle = pick(angles);
   const device = pick(devices);

--- a/lib/openaiClient.js
+++ b/lib/openaiClient.js
@@ -1,0 +1,60 @@
+import OpenAI from 'openai'
+import fs from 'fs'
+import path from 'path'
+
+let cachedClient = null
+let cachedJokes = null
+
+function loadLocalJokes() {
+  if (cachedJokes) {
+    return cachedJokes
+  }
+  const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt')
+  const jokes = fs
+    .readFileSync(jokesPath, 'utf-8')
+    .split('\n\n')
+    .filter(Boolean)
+  cachedJokes = jokes
+  return jokes
+}
+
+function createMockClient() {
+  const jokes = loadLocalJokes()
+  return {
+    __mock: true,
+    responses: {
+      async create({ stream }) {
+        const joke = jokes[Math.floor(Math.random() * jokes.length)]
+        if (stream) {
+          async function* generator() {
+            for (const char of joke) {
+              await new Promise((resolve) => setTimeout(resolve, 5))
+              yield { delta: char }
+            }
+          }
+          return generator()
+        }
+        return { output_text: joke }
+      }
+    }
+  }
+}
+
+export function getOpenAIClient() {
+  if (cachedClient) {
+    return cachedClient
+  }
+  if (process.env.MOCK_OPENAI === 'true' || !process.env.API_KEY) {
+    cachedClient = createMockClient()
+    return cachedClient
+  }
+  cachedClient = new OpenAI({
+    apiKey: process.env.API_KEY
+  })
+  return cachedClient
+}
+
+export function getRandomLocalJoke() {
+  const jokes = loadLocalJokes()
+  return jokes[Math.floor(Math.random() * jokes.length)]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^0.1.6",
+        "@vercel/kv": "^3.0.0",
         "eslint": "8.28.0",
         "eslint-config-next": "13.0.6",
         "next": "13.0.6",
@@ -2540,12 +2541,33 @@
         "win32"
       ]
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.5",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.5.tgz",
+      "integrity": "sha512-KdLdNAspQGOTGeC++o2LDBzNbMXrfInnmW5nUJfNXabnVh8X4NPrlJ0X4j75cBUShiMpXB3uI1ql4KpFQeqrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/@vercel/analytics": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-0.1.6.tgz",
       "integrity": "sha512-zNd5pj3iDvq8IMBQHa1YRcIteiw6ZiPB8AsONHd8ieFXlNpLqhXfIYnf4WvTfZ7S1NSJ++mIM14aJnNac/VMXQ==",
       "peerDependencies": {
         "react": "^16.8||^17||^18"
+      }
+    },
+    "node_modules/@vercel/kv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@upstash/redis": "^1.34.0"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/accepts": {
@@ -7563,6 +7585,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
@@ -9558,11 +9586,27 @@
       "dev": true,
       "optional": true
     },
+    "@upstash/redis": {
+      "version": "1.35.5",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.5.tgz",
+      "integrity": "sha512-KdLdNAspQGOTGeC++o2LDBzNbMXrfInnmW5nUJfNXabnVh8X4NPrlJ0X4j75cBUShiMpXB3uI1ql4KpFQeqrHQ==",
+      "requires": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "@vercel/analytics": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-0.1.6.tgz",
       "integrity": "sha512-zNd5pj3iDvq8IMBQHa1YRcIteiw6ZiPB8AsONHd8ieFXlNpLqhXfIYnf4WvTfZ7S1NSJ++mIM14aJnNac/VMXQ==",
       "requires": {}
+    },
+    "@vercel/kv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+      "requires": {
+        "@upstash/redis": "^1.34.0"
+      }
     },
     "accepts": {
       "version": "1.3.8",
@@ -12982,6 +13026,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "undici-types": {
       "version": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^0.1.6",
+    "@vercel/kv": "^3.0.0",
     "eslint": "8.28.0",
     "eslint-config-next": "13.0.6",
     "next": "13.0.6",

--- a/pages/api/daily-joke.js
+++ b/pages/api/daily-joke.js
@@ -1,0 +1,148 @@
+import { kv } from '@vercel/kv'
+import { generatePrompt } from '../../lib/generatePrompt.mjs'
+import { getOpenAIClient, getRandomLocalJoke } from '../../lib/openaiClient'
+
+const KV_PREFIX = 'daily-joke:'
+const kvConfigured = Boolean(
+  process.env.KV_REST_API_URL &&
+  process.env.KV_REST_API_TOKEN &&
+  process.env.KV_REST_API_READ_ONLY_TOKEN
+)
+
+const memoryStore = globalThis.__dailyJokeStore || new Map()
+if (!globalThis.__dailyJokeStore) {
+  globalThis.__dailyJokeStore = memoryStore
+}
+
+function getDateKey() {
+  const now = new Date()
+  return now.toISOString().slice(0, 10)
+}
+
+async function readCachedJoke(dateKey) {
+  const key = `${KV_PREFIX}${dateKey}`
+  if (kvConfigured) {
+    const stored = await kv.get(key)
+    if (stored) {
+      return stored
+    }
+    return null
+  }
+  return memoryStore.get(key) || null
+}
+
+async function writeCachedJoke(dateKey, payload) {
+  const key = `${KV_PREFIX}${dateKey}`
+  if (kvConfigured) {
+    await kv.set(key, payload, { ex: 60 * 60 * 24 })
+    return
+  }
+  memoryStore.set(key, payload)
+}
+
+async function fetchOnThisDayEvent(dateKey) {
+  const [year, month, day] = dateKey.split('-')
+  const endpoint = `https://en.wikipedia.org/api/rest_v1/feed/onthisday/events/${Number(
+    month
+  )}/${Number(day)}`
+  const res = await fetch(endpoint)
+  if (!res.ok) {
+    throw new Error('Unable to fetch historical context')
+  }
+  const data = await res.json()
+  const events = Array.isArray(data?.events) ? data.events : []
+  if (events.length === 0) {
+    throw new Error('No events available for today')
+  }
+  // Deterministically pick an event based on the year and index so all deployments agree
+  const indexSeed = Number(year) + Number(month) + Number(day)
+  const event = events[indexSeed % events.length]
+  const page = Array.isArray(event?.pages) ? event.pages[0] : null
+  const source = page?.content_urls?.desktop?.page || page?.content_urls?.mobile?.page
+  return {
+    year: event?.year || null,
+    text: event?.text || '',
+    title: event?.title || page?.titles?.normalized || '',
+    summary: page?.extract || '',
+    source: source || null
+  }
+}
+
+function extractTextFromResponse(response) {
+  if (!response) {
+    return ''
+  }
+  if (typeof response === 'string') {
+    return response
+  }
+  if (response.output_text) {
+    return response.output_text
+  }
+  if (Array.isArray(response.output)) {
+    const text = response.output
+      .flatMap((item) => item?.content || [])
+      .map((chunk) => chunk?.text || '')
+      .join('')
+    if (text) {
+      return text
+    }
+  }
+  return ''
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    res.status(405).end('Method Not Allowed')
+    return
+  }
+
+  const dateKey = getDateKey()
+
+  try {
+    const cached = await readCachedJoke(dateKey)
+    if (cached) {
+      res.status(200).json(cached)
+      return
+    }
+  } catch (error) {
+    // Swallow cache read errors so we can try to generate a joke anyway
+  }
+
+  try {
+    const event = await fetchOnThisDayEvent(dateKey)
+    const prompt = generatePrompt({ mode: 'daily', event })
+    const openai = getOpenAIClient()
+    const response = await openai.responses.create({
+      model: 'gpt-4o-mini',
+      input: prompt,
+      temperature: 0.8,
+      stream: false
+    })
+    const joke = extractTextFromResponse(response)
+    const payload = {
+      joke: joke || getRandomLocalJoke(),
+      context: {
+        date: dateKey,
+        year: event.year,
+        text: event.text,
+        summary: event.summary,
+        source: event.source
+      }
+    }
+    await writeCachedJoke(dateKey, payload)
+    res.status(200).json(payload)
+  } catch (error) {
+    const fallback = {
+      joke: `Question: Why did the calendar apply for a job?\nAnswer: It wanted to take advantage of all its dates!`,
+      context: {
+        date: dateKey,
+        year: null,
+        text: 'Unable to fetch on-this-day facts, serving a timeless dad joke instead.',
+        summary: '',
+        source: null
+      }
+    }
+    res.status(200).json(fallback)
+  }
+}

--- a/pages/api/openai.js
+++ b/pages/api/openai.js
@@ -1,63 +1,7 @@
-import OpenAI from 'openai';
-import fs from 'fs';
-import path from 'path';
 import { generatePrompt } from '../../lib/generatePrompt.mjs';
+import { getOpenAIClient, getRandomLocalJoke } from '../../lib/openaiClient';
 
-/*
- * When running locally without a valid API key (for example, during development
- * or in CI where the OpenAI API cannot be reached), we mock the minimal
- * portion of the OpenAI library used in this handler. The mock returns a
- * predictable topic and an asynchronous generator that yields a simple dad
- * joke character by character. To enable the mock, either set the
- * environment variable MOCK_OPENAI to "true" or omit API_KEY entirely.
- */
-let openai;
-if (process.env.MOCK_OPENAI === 'true' || !process.env.API_KEY) {
-  // Read the list of dad jokes once so we can serve a random one when mocking
-  const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt');
-  const jokes = fs
-    .readFileSync(jokesPath, 'utf-8')
-    .split('\n\n')
-    .filter(Boolean);
-
-  // Define a mock responses API that mirrors the interface used below
-  openai = {
-    responses: {
-      /**
-       * Mock implementation of `responses.create`.
-       * When called without streaming, returns a dummy value (not used in this implementation).
-       * When called with streaming enabled, returns an async generator that yields a
-       * dad joke character by character from the local jokes file.
-       */
-      async create({ stream }) {
-        if (!stream) {
-          // No streaming call should be made without stream in this implementation
-          return { output_text: '' };
-        }
-        // Select a random joke from the dataset
-        const joke = jokes[Math.floor(Math.random() * jokes.length)];
-        async function* generator() {
-          for (const char of joke) {
-            // Wait a tiny bit between characters to better simulate streaming
-            await new Promise((resolve) => setTimeout(resolve, 5));
-            yield { delta: char };
-          }
-        }
-        return generator();
-      }
-    }
-  };
-} else {
-  openai = new OpenAI({
-    apiKey: process.env.API_KEY
-  });
-}
-
-const getRandomJoke = () => {
-  const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt');
-  const jokes = fs.readFileSync(jokesPath, 'utf-8').split('\n\n').filter(Boolean);
-  return jokes[Math.floor(Math.random() * jokes.length)];
-};
+const openai = getOpenAIClient();
 
 export default async function handler(req, res) {
   // Configure Server-Sent Events headers
@@ -94,7 +38,7 @@ export default async function handler(req, res) {
     res.write('data: [DONE]\n\n');
     res.end();
   } catch (error) {
-    const joke = getRandomJoke();
+    const joke = getRandomLocalJoke();
     res.write(`data: ${joke}\n\n`);
     res.write('data: [DONE]\n\n');
     res.end();

--- a/pages/api/ratings.js
+++ b/pages/api/ratings.js
@@ -1,0 +1,121 @@
+import { kv } from '@vercel/kv'
+
+const KV_PREFIX = 'groan-ratings:'
+const DEFAULT_COUNTS = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+const memoryStore = globalThis.__groanRatingsStore || new Map()
+if (!globalThis.__groanRatingsStore) {
+  globalThis.__groanRatingsStore = memoryStore
+}
+
+const kvConfigured = Boolean(
+  process.env.KV_REST_API_URL &&
+  process.env.KV_REST_API_TOKEN &&
+  process.env.KV_REST_API_READ_ONLY_TOKEN
+)
+
+function buildDefaultStats(overrides = {}) {
+  return {
+    counts: { ...DEFAULT_COUNTS },
+    totalRatings: 0,
+    average: 0,
+    ...overrides
+  }
+}
+
+async function readStats(jokeId) {
+  const key = `${KV_PREFIX}${jokeId}`
+  if (kvConfigured) {
+    const stored = await kv.get(key)
+    if (stored) {
+      return normalizeStats(stored)
+    }
+    const initial = buildDefaultStats()
+    await kv.set(key, initial)
+    return initial
+  }
+  return memoryStore.get(key) || buildDefaultStats()
+}
+
+async function writeStats(jokeId, stats) {
+  const key = `${KV_PREFIX}${jokeId}`
+  if (kvConfigured) {
+    await kv.set(key, stats)
+    return
+  }
+  memoryStore.set(key, stats)
+}
+
+function normalizeStats(stats) {
+  const counts = { ...DEFAULT_COUNTS, ...(stats?.counts || {}) }
+  const totalRatings = Number(stats?.totalRatings || 0)
+  const average = Number(stats?.average || 0)
+  return { counts, totalRatings, average }
+}
+
+function validateRating(value) {
+  const rating = Number(value)
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    return null
+  }
+  return rating
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const { jokeId } = req.query
+    if (!jokeId || typeof jokeId !== 'string') {
+      res.status(400).json({ error: 'Missing jokeId' })
+      return
+    }
+    try {
+      const stats = await readStats(jokeId)
+      res.status(200).json(stats)
+    } catch (error) {
+      res.status(500).json({ error: 'Unable to load ratings' })
+    }
+    return
+  }
+
+  if (req.method === 'POST') {
+    const { jokeId, rating, joke } = req.body || {}
+    if (!jokeId || typeof jokeId !== 'string') {
+      res.status(400).json({ error: 'Missing jokeId' })
+      return
+    }
+    const parsedRating = validateRating(rating)
+    if (!parsedRating) {
+      res.status(422).json({ error: 'Rating must be an integer between 1 and 5' })
+      return
+    }
+
+    try {
+      const stats = await readStats(jokeId)
+      const counts = { ...stats.counts }
+      counts[parsedRating] = (counts[parsedRating] || 0) + 1
+      const totalRatings = Object.values(counts).reduce((acc, val) => acc + val, 0)
+      const totalScore = Object.entries(counts).reduce(
+        (acc, [score, count]) => acc + Number(score) * count,
+        0
+      )
+      const average = totalRatings === 0 ? 0 : Number((totalScore / totalRatings).toFixed(2))
+
+      const updatedStats = {
+        counts,
+        totalRatings,
+        average
+      }
+      if (joke && typeof joke === 'string') {
+        updatedStats.joke = joke
+      }
+
+      await writeStats(jokeId, updatedStats)
+      res.status(200).json(updatedStats)
+    } catch (error) {
+      res.status(500).json({ error: 'Unable to save rating' })
+    }
+    return
+  }
+
+  res.setHeader('Allow', ['GET', 'POST'])
+  res.status(405).end('Method Not Allowed')
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,20 @@ import Header from '../components/Header'
 import Spinner from '../components/Spinner'
 import { parseStream } from '../lib/parseJokeStream'
 
+const defaultRatingStats = {
+  counts: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
+  average: 0,
+  totalRatings: 0
+}
+
+function normalizeStats(stats = {}) {
+  return {
+    counts: { ...defaultRatingStats.counts, ...(stats.counts || {}) },
+    average: Number(stats.average || 0),
+    totalRatings: Number(stats.totalRatings || 0)
+  }
+}
+
 
 class OpenAIData extends React.Component {
   constructor(props) {
@@ -17,14 +31,149 @@ class OpenAIData extends React.Component {
       answer: "",
       questionTokens: [],
       answerTokens: [],
-      pendingQuestion: ''
+      pendingQuestion: '',
+      ratingStats: { ...defaultRatingStats },
+      userRating: null,
+      isSubmittingRating: false,
+      ratingError: null,
+      hasSubmittedRating: false,
+      currentJokeId: null,
+      currentJokeText: '',
+      jokeMode: 'live',
+      dailyContext: null
     };
     this.eventSource = null;
   }
 
   componentDidMount() {
-    // Load the initial joke when the component mounts
+    const defaultMode =
+      typeof process !== 'undefined' &&
+      process.env.NEXT_PUBLIC_DEFAULT_JOKE_MODE === 'daily'
+        ? 'daily'
+        : 'live';
+    let savedMode = null;
+    try {
+      savedMode = window.localStorage.getItem('jokeMode');
+    } catch (error) {
+      savedMode = null;
+    }
+    const mode = savedMode === 'daily' ? 'daily' : defaultMode;
+    this.setState({ jokeMode: mode }, () => {
+      this.loadJokeForMode(mode);
+    });
+  }
+
+  componentWillUnmount() {
+    if (this.eventSource) {
+      this.eventSource.close();
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      this.state.isComplete &&
+      (prevState.questionTokens !== this.state.questionTokens ||
+        prevState.answerTokens !== this.state.answerTokens ||
+        prevState.isComplete !== this.state.isComplete)
+    ) {
+      this.prepareJokeMetadata();
+    }
+  }
+
+  prepareJokeMetadata = () => {
+    const { questionTokens, answerTokens, currentJokeId } = this.state;
+    const question = questionTokens.join(' ').trim();
+    const answer = answerTokens.join(' ').trim();
+    if (!question && !answer) {
+      return;
+    }
+    const parts = [];
+    if (question) parts.push(question);
+    if (answer) parts.push(answer);
+    const jokeText = parts.join(' || ').trim();
+    const jokeId = this.createJokeId(jokeText);
+    if (jokeId === currentJokeId) {
+      return;
+    }
+    this.setState(
+      {
+        currentJokeId: jokeId,
+        currentJokeText: jokeText,
+        ratingStats: { ...defaultRatingStats },
+        userRating: null,
+        isSubmittingRating: false,
+        ratingError: null,
+        hasSubmittedRating: false
+      },
+      () => {
+        this.fetchRatingStats(jokeId);
+      }
+    );
+  }
+
+  loadJokeForMode = (mode) => {
+    if (mode === 'daily') {
+      this.fetchDailyJoke();
+      return;
+    }
     this.fetchJoke();
+  }
+
+  createJokeId = (text) => {
+    let hash = 0;
+    for (let i = 0; i < text.length; i += 1) {
+      hash = (hash << 5) - hash + text.charCodeAt(i);
+      hash |= 0;
+    }
+    return `joke-${Math.abs(hash)}`;
+  }
+
+  fetchRatingStats = async (jokeId) => {
+    try {
+      const response = await fetch(`/api/ratings?jokeId=${encodeURIComponent(jokeId)}`);
+      if (!response.ok) {
+        throw new Error('Unable to load ratings');
+      }
+      const data = await response.json();
+      this.setState({ ratingStats: normalizeStats(data), ratingError: null });
+    } catch (error) {
+      this.setState({ ratingError: error, ratingStats: { ...defaultRatingStats } });
+    }
+  }
+
+  handleGroanClick = async (value) => {
+    const { currentJokeId, currentJokeText, hasSubmittedRating, isSubmittingRating } = this.state;
+    if (!currentJokeId || hasSubmittedRating || isSubmittingRating) {
+      return;
+    }
+    this.setState({ userRating: value, isSubmittingRating: true, ratingError: null });
+    try {
+      const response = await fetch('/api/ratings', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          jokeId: currentJokeId,
+          rating: value,
+          joke: currentJokeText
+        })
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.error || 'Unable to save rating');
+      }
+      const data = await response.json();
+      this.setState({
+        ratingStats: normalizeStats(data),
+        hasSubmittedRating: true,
+        ratingError: null
+      });
+    } catch (error) {
+      this.setState({ ratingError: error });
+    } finally {
+      this.setState({ isSubmittingRating: false });
+    }
   }
 
   fetchJoke = () => {
@@ -41,7 +190,15 @@ class OpenAIData extends React.Component {
       answer: '',
       questionTokens: [],
       answerTokens: [],
-      pendingQuestion: ''
+      pendingQuestion: '',
+      ratingStats: { ...defaultRatingStats },
+      userRating: null,
+      isSubmittingRating: false,
+      ratingError: null,
+      hasSubmittedRating: false,
+      currentJokeId: null,
+      currentJokeText: '',
+      dailyContext: null
     });
 
     // Establish an EventSource connection to receive SSEs from the backend
@@ -82,6 +239,64 @@ class OpenAIData extends React.Component {
     };
   }
 
+  fetchDailyJoke = async () => {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    this.setState({
+      error: null,
+      isLoaded: false,
+      isComplete: false,
+      question: '',
+      answer: '',
+      questionTokens: [],
+      answerTokens: [],
+      pendingQuestion: '',
+      ratingStats: { ...defaultRatingStats },
+      userRating: null,
+      isSubmittingRating: false,
+      ratingError: null,
+      hasSubmittedRating: false,
+      currentJokeId: null,
+      currentJokeText: '',
+      dailyContext: null
+    });
+    try {
+      const res = await fetch('/api/daily-joke');
+      if (!res.ok) {
+        throw new Error('Unable to load the daily joke');
+      }
+      const data = await res.json();
+      const initialState = {
+        question: '',
+        answer: '',
+        questionTokens: [],
+        answerTokens: [],
+        pendingQuestion: ''
+      };
+      const parsed = parseStream(data.joke || '', initialState);
+      this.setState(
+        {
+          ...parsed,
+          isLoaded: true,
+          isComplete: true,
+          error: null,
+          dailyContext: data.context || null
+        },
+        () => {
+          this.prepareJokeMetadata();
+        }
+      );
+    } catch (error) {
+      this.setState({
+        error,
+        isLoaded: true,
+        isComplete: true
+      });
+    }
+  }
+
   loadFallbackJoke = async () => {
     try {
       const res = await fetch('/api/random-joke');
@@ -109,14 +324,35 @@ class OpenAIData extends React.Component {
     }
   }
 
-  componentWillUnmount() {
-    if (this.eventSource) {
-      this.eventSource.close();
+  handleModeChange = (mode) => {
+    if (mode === this.state.jokeMode) {
+      return;
     }
+    try {
+      window.localStorage.setItem('jokeMode', mode);
+    } catch (error) {
+      // Ignore storage failures
+    }
+    this.setState({ jokeMode: mode }, () => {
+      this.loadJokeForMode(mode);
+    });
   }
 
   render() {
-    const { error, isLoaded, isComplete, questionTokens, answerTokens } = this.state;
+    const {
+      error,
+      isLoaded,
+      isComplete,
+      questionTokens,
+      answerTokens,
+      ratingStats,
+      userRating,
+      isSubmittingRating,
+      ratingError,
+      hasSubmittedRating,
+      jokeMode,
+      dailyContext
+    } = this.state;
     if (error) {
       return <div>Error Loading: {error.message}</div>;
     }
@@ -127,6 +363,22 @@ class OpenAIData extends React.Component {
       <div className={styles.jokeContainer}>
         {/* Update the header to be a bit more playful */}
         <h2 className={styles.jokeHeader}>Dad Joke of the Day (Guaranteed to Make You Groan)</h2>
+        <div className={styles.modeToggle}>
+          <button
+            type="button"
+            className={`${styles.modeButton} ${jokeMode === 'live' ? styles.modeButtonActive : ''}`}
+            onClick={() => this.handleModeChange('live')}
+          >
+            Live Stream
+          </button>
+          <button
+            type="button"
+            className={`${styles.modeButton} ${jokeMode === 'daily' ? styles.modeButtonActive : ''}`}
+            onClick={() => this.handleModeChange('daily')}
+          >
+            Joke of the Day
+          </button>
+        </div>
         {questionTokens.length > 0 && (
           <p className={styles.question}>
             {questionTokens.map((t, i) => (
@@ -142,9 +394,78 @@ class OpenAIData extends React.Component {
           </p>
         )}
         {isComplete && (
-          <button className={styles.newJokeButton} onClick={this.fetchJoke}>
-            New Joke
+          <>
+            <div className={styles.ratingSection}>
+              <p className={styles.ratingPrompt}>How many groans does this joke deserve?</p>
+              <div className={styles.groanButtonGroup}>
+                {[1, 2, 3, 4, 5].map((value) => {
+                  const isActive = userRating ? value <= userRating : false;
+                  const buttonClass = `${styles.groanButton} ${isActive ? styles.groanButtonActive : ''}`;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      className={buttonClass}
+                      onClick={() => this.handleGroanClick(value)}
+                      disabled={isSubmittingRating || hasSubmittedRating}
+                      aria-label={`${value} groan${value === 1 ? '' : 's'}`}
+                    >
+                      {value}
+                    </button>
+                  );
+                })}
+              </div>
+              <div className={styles.ratingSummary}>
+                {ratingStats.totalRatings > 0 ? (
+                  <p>
+                    Average rating: <strong>{ratingStats.average}</strong> groans ·{' '}
+                    {ratingStats.totalRatings} total rating{ratingStats.totalRatings === 1 ? '' : 's'}
+                  </p>
+                ) : (
+                  <p>Be the first to rate this groaner.</p>
+                )}
+                {hasSubmittedRating && (
+                  <p className={styles.ratingThanks}>Thanks for letting us know how much you groaned!</p>
+                )}
+                {ratingError && (
+                  <p className={styles.ratingError}>We couldn't save your rating. Please try again.</p>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+        {isComplete && (
+          <button
+            className={styles.newJokeButton}
+            onClick={jokeMode === 'daily' ? this.fetchDailyJoke : this.fetchJoke}
+          >
+            {jokeMode === 'daily' ? 'Reload Daily Joke' : 'New Joke'}
           </button>
+        )}
+        {jokeMode === 'daily' && dailyContext && (
+          <div className={styles.dailyContext}>
+            <h3>Why today?</h3>
+            {dailyContext.year ? (
+              <p>
+                In {dailyContext.year}, {dailyContext.text}
+              </p>
+            ) : (
+              <p>{dailyContext.text}</p>
+            )}
+            {dailyContext.summary && (
+              <p className={styles.dailySummary}>{dailyContext.summary}</p>
+            )}
+            {dailyContext.source && (
+              <a
+                className={styles.dailyLink}
+                href={dailyContext.source}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Read more about today&apos;s event
+              </a>
+            )}
+          </div>
         )}
       </div>
     );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -252,10 +252,135 @@
   transform: translateY(-2px);
 }
 
+.modeToggle {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.modeButton {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-dark);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.modeButton:hover {
+  border-color: var(--color-primary);
+  transform: translateY(-1px);
+}
+
+.modeButtonActive {
+  background: var(--color-primary);
+  color: #000;
+  border-color: var(--color-primary);
+  font-weight: 600;
+}
+
+.dailyContext {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--color-border-dark);
+  line-height: 1.5;
+}
+
+.dailyContext h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.25rem;
+}
+
+.dailySummary {
+  margin-top: 0.5rem;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dailyLink {
+  display: inline-block;
+  margin-top: 0.75rem;
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.dailyLink:hover,
+.dailyLink:focus {
+  color: #f7dc6f;
+}
+
 /* Simple fade-in utility for question and answer text */
 .fadeIn {
   opacity: 0;
   animation: fadeIn 0.5s ease-in forwards;
+}
+
+.ratingSection {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border-dark);
+  border-radius: 8px;
+  background-color: rgba(255, 255, 255, 0.03);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+}
+
+.ratingPrompt {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.groanButtonGroup {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.groanButton {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface-dark);
+  color: var(--color-text);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.groanButton:hover:not(:disabled) {
+  transform: translateY(-2px);
+  border-color: var(--color-primary);
+}
+
+.groanButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.groanButtonActive {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #000;
+  font-weight: 700;
+}
+
+.ratingSummary p {
+  margin: 0.25rem 0;
+}
+
+.ratingThanks {
+  color: #2ecc71;
+  font-weight: 600;
+}
+
+.ratingError {
+  color: #e74c3c;
+  font-weight: 600;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- add a toggle so the homepage can switch between live streaming jokes and a daily joke mode
- fetch and cache daily jokes with on-this-day context via a new API backed by the shared OpenAI client
- document how to default to the daily mode and surface the historical reference beneath the joke

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b0761fd483288f20acebbd5ba8f4