### PR TITLE
Default to daily jokes and update blob token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,35 @@ You can start editing the page by modifying `pages/index.js`. The page auto-upda
 
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
 
+## Groan ratings & free storage option
+
+The home page now lets visitors rate each joke on a five groan scale. Ratings are persisted through the `/api/ratings` route, which stores daily aggregates in [Vercel Blob](https://vercel.com/docs/storage/vercel-blob). Each vote is appended to a JSON document located at `groan-ratings/<yyyy-mm-dd>/<joke-id>.json`, making it easy to review stats for a single joke or analyze everything that landed on a specific day.
+
+1. In the Vercel dashboard, create a Blob store (the free hobby tier is plenty for text-sized payloads).
+2. Copy the `DAD_READ_WRITE_TOKEN` from the store settings and expose it to the app:
+
+   ```bash
+   DAD_READ_WRITE_TOKEN=<value>
+   ```
+
+3. Redeploy. The `/api/ratings` route will start reading/writing daily JSON blobs. When the token is absent (for example during local development), the route falls back to an in-memory store so the UI can still be exercised.
+
+## Joke of the day mode
+
+If you want to track a single joke over the course of the day, switch the homepage into **Joke of the Day** mode using the toggle above the joke. When active the app:
+
+- Calls `/api/daily-joke`, which fetches "On this day" facts from Wikipedia's public REST API.
+- Generates a dad joke that references the selected historical event and caches it in Vercel Blob (or an in-memory fallback) so everyone sees the same joke for that date.
+- Surfaces the historical context, including a summary and source link, under the joke so you know why the gag is timely.
+
+By default the homepage loads the daily joke so it is easy to track ratings by date. If you would rather stream jokes on first visit, set an environment variable before building the app:
+
+```bash
+NEXT_PUBLIC_DEFAULT_JOKE_MODE=live
+```
+
+With the variable set to `live`, visitors land on the streaming mode but can still switch back to the date-aware daily joke at any time.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/lib/generatePrompt.mjs
+++ b/lib/generatePrompt.mjs
@@ -67,7 +67,35 @@ function pick(arr) {
   return arr[randomInt(arr.length)];
 }
 
-export function generatePrompt() {
+function buildDailyPrompt(event) {
+  const {
+    year,
+    text,
+    title,
+    summary,
+    source
+  } = event;
+  const description = summary || text || title;
+  const sourceLine = source ? `Use this reference for context: ${source}.` : '';
+  return [
+    'Craft a dad joke that feels timely for today. Use the details below as inspiration and weave them into the setup or punchline in a playful way:',
+    `Event: ${description}`,
+    year ? `Happened in: ${year}` : '',
+    sourceLine,
+    'Keep the humor groan-worthy but warm-hearted, and make sure the joke makes it clear why the event or date matters.',
+    'Avoid using special characters or symbols; respond with plain text only.',
+    'Return the joke on exactly two lines labeled like:',
+    'Question: <setup>',
+    'Answer: <punchline>'
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function generatePrompt(options = {}) {
+  if (options.mode === 'daily' && options.event) {
+    return buildDailyPrompt(options.event);
+  }
   const topic = pick(topics);
   const angle = pick(angles);
   const device = pick(devices);

--- a/lib/openaiClient.js
+++ b/lib/openaiClient.js
@@ -1,0 +1,60 @@
+import OpenAI from 'openai'
+import fs from 'fs'
+import path from 'path'
+
+let cachedClient = null
+let cachedJokes = null
+
+function loadLocalJokes() {
+  if (cachedJokes) {
+    return cachedJokes
+  }
+  const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt')
+  const jokes = fs
+    .readFileSync(jokesPath, 'utf-8')
+    .split('\n\n')
+    .filter(Boolean)
+  cachedJokes = jokes
+  return jokes
+}
+
+function createMockClient() {
+  const jokes = loadLocalJokes()
+  return {
+    __mock: true,
+    responses: {
+      async create({ stream }) {
+        const joke = jokes[Math.floor(Math.random() * jokes.length)]
+        if (stream) {
+          async function* generator() {
+            for (const char of joke) {
+              await new Promise((resolve) => setTimeout(resolve, 5))
+              yield { delta: char }
+            }
+          }
+          return generator()
+        }
+        return { output_text: joke }
+      }
+    }
+  }
+}
+
+export function getOpenAIClient() {
+  if (cachedClient) {
+    return cachedClient
+  }
+  if (process.env.MOCK_OPENAI === 'true' || !process.env.API_KEY) {
+    cachedClient = createMockClient()
+    return cachedClient
+  }
+  cachedClient = new OpenAI({
+    apiKey: process.env.API_KEY
+  })
+  return cachedClient
+}
+
+export function getRandomLocalJoke() {
+  const jokes = loadLocalJokes()
+  return jokes[Math.floor(Math.random() * jokes.length)]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^0.1.6",
+        "@vercel/blob": "^2.0.0",
         "eslint": "8.28.0",
         "eslint-config-next": "13.0.6",
         "next": "13.0.6",
@@ -785,6 +786,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2548,6 +2558,22 @@
         "react": "^16.8||^17||^18"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.0.0.tgz",
+      "integrity": "sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2764,6 +2790,15 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/axe-core": {
       "version": "4.5.2",
@@ -4581,6 +4616,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -4680,6 +4738,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6885,6 +6949,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7368,6 +7441,18 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tiny-glob": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
@@ -7561,6 +7646,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {
@@ -8417,6 +8514,11 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -9564,6 +9666,18 @@
       "integrity": "sha512-zNd5pj3iDvq8IMBQHa1YRcIteiw6ZiPB8AsONHd8ieFXlNpLqhXfIYnf4WvTfZ7S1NSJ++mIM14aJnNac/VMXQ==",
       "requires": {}
     },
+    "@vercel/blob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.0.0.tgz",
+      "integrity": "sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw==",
+      "requires": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^5.28.4"
+      }
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -9711,6 +9825,14 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
+      }
     },
     "axe-core": {
       "version": "4.5.2",
@@ -10979,6 +11101,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -11034,6 +11161,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
+    },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="
     },
     "is-number": {
       "version": "7.0.0",
@@ -12519,6 +12651,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -12841,6 +12978,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="
+    },
     "tiny-glob": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
@@ -12981,6 +13123,14 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
       }
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^0.1.6",
+    "@vercel/blob": "^2.0.0",
     "eslint": "8.28.0",
     "eslint-config-next": "13.0.6",
     "next": "13.0.6",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,5 @@
 import '../styles/globals.css'
 import { useEffect } from 'react';
-import Head from 'next/head';
 import ReactGA from 'react-ga';
 
 const TRACKING_ID = "UA-48759266-1"; // OUR_TRACKING_ID
@@ -17,19 +16,7 @@ function MyApp({ Component, pageProps }) {
     }
   }, []);
 
-  return (
-    <>
-      <Head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
-          rel="stylesheet"
-        />
-      </Head>
-      <Component {...pageProps} />
-    </>
-  )
+  return <Component {...pageProps} />
 }
 
 export default MyApp

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,20 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/api/daily-joke.js
+++ b/pages/api/daily-joke.js
@@ -1,0 +1,162 @@
+import { BlobNotFoundError, head, put } from '@vercel/blob'
+import { generatePrompt } from '../../lib/generatePrompt.mjs'
+import { getOpenAIClient, getRandomLocalJoke } from '../../lib/openaiClient'
+
+const BLOB_PREFIX = 'daily-joke'
+const blobToken = process.env.DAD_READ_WRITE_TOKEN
+const blobConfigured = Boolean(blobToken)
+
+const memoryStore = globalThis.__dailyJokeStore || new Map()
+if (!globalThis.__dailyJokeStore) {
+  globalThis.__dailyJokeStore = memoryStore
+}
+
+function getDateKey() {
+  const now = new Date()
+  return now.toISOString().slice(0, 10)
+}
+
+function getBlobPath(dateKey) {
+  return `${BLOB_PREFIX}/${dateKey}.json`
+}
+
+async function readCachedJoke(dateKey) {
+  if (blobConfigured) {
+    const path = getBlobPath(dateKey)
+    try {
+      const metadata = await head(path, { token: blobToken })
+      const response = await fetch(metadata.downloadUrl)
+      if (!response.ok) {
+        throw new Error('Unable to download cached joke')
+      }
+      return await response.json()
+    } catch (error) {
+      if (error instanceof BlobNotFoundError || error?.name === 'BlobNotFoundError') {
+        return null
+      }
+      throw error
+    }
+  }
+  return memoryStore.get(dateKey) || null
+}
+
+async function writeCachedJoke(dateKey, payload) {
+  if (blobConfigured) {
+    const path = getBlobPath(dateKey)
+    await put(path, JSON.stringify(payload), {
+      access: 'public',
+      contentType: 'application/json',
+      cacheControl: 'public, max-age=300, s-maxage=300',
+      token: blobToken
+    })
+    return
+  }
+  memoryStore.set(dateKey, payload)
+}
+
+async function fetchOnThisDayEvent(dateKey) {
+  const [year, month, day] = dateKey.split('-')
+  const endpoint = `https://en.wikipedia.org/api/rest_v1/feed/onthisday/events/${Number(
+    month
+  )}/${Number(day)}`
+  const res = await fetch(endpoint)
+  if (!res.ok) {
+    throw new Error('Unable to fetch historical context')
+  }
+  const data = await res.json()
+  const events = Array.isArray(data?.events) ? data.events : []
+  if (events.length === 0) {
+    throw new Error('No events available for today')
+  }
+  // Deterministically pick an event based on the year and index so all deployments agree
+  const indexSeed = Number(year) + Number(month) + Number(day)
+  const event = events[indexSeed % events.length]
+  const page = Array.isArray(event?.pages) ? event.pages[0] : null
+  const source = page?.content_urls?.desktop?.page || page?.content_urls?.mobile?.page
+  return {
+    year: event?.year || null,
+    text: event?.text || '',
+    title: event?.title || page?.titles?.normalized || '',
+    summary: page?.extract || '',
+    source: source || null
+  }
+}
+
+function extractTextFromResponse(response) {
+  if (!response) {
+    return ''
+  }
+  if (typeof response === 'string') {
+    return response
+  }
+  if (response.output_text) {
+    return response.output_text
+  }
+  if (Array.isArray(response.output)) {
+    const text = response.output
+      .flatMap((item) => item?.content || [])
+      .map((chunk) => chunk?.text || '')
+      .join('')
+    if (text) {
+      return text
+    }
+  }
+  return ''
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    res.status(405).end('Method Not Allowed')
+    return
+  }
+
+  const dateKey = getDateKey()
+
+  try {
+    const cached = await readCachedJoke(dateKey)
+    if (cached) {
+      res.status(200).json(cached)
+      return
+    }
+  } catch (error) {
+    // Swallow cache read errors so we can try to generate a joke anyway
+  }
+
+  try {
+    const event = await fetchOnThisDayEvent(dateKey)
+    const prompt = generatePrompt({ mode: 'daily', event })
+    const openai = getOpenAIClient()
+    const response = await openai.responses.create({
+      model: 'gpt-4o-mini',
+      input: prompt,
+      temperature: 0.8,
+      stream: false
+    })
+    const joke = extractTextFromResponse(response)
+    const payload = {
+      joke: joke || getRandomLocalJoke(),
+      context: {
+        date: dateKey,
+        year: event.year,
+        text: event.text,
+        summary: event.summary,
+        source: event.source
+      }
+    }
+    await writeCachedJoke(dateKey, payload)
+    res.status(200).json(payload)
+  } catch (error) {
+    const fallback = {
+      joke: `Question: Why did the calendar apply for a job?\nAnswer: It wanted to take advantage of all its dates!`,
+      context: {
+        date: dateKey,
+        year: null,
+        text: 'Unable to fetch on-this-day facts, serving a timeless dad joke instead.',
+        summary: '',
+        source: null
+      }
+    }
+    res.status(200).json(fallback)
+  }
+}

--- a/pages/api/openai.js
+++ b/pages/api/openai.js
@@ -1,63 +1,7 @@
-import OpenAI from 'openai';
-import fs from 'fs';
-import path from 'path';
 import { generatePrompt } from '../../lib/generatePrompt.mjs';
+import { getOpenAIClient, getRandomLocalJoke } from '../../lib/openaiClient';
 
-/*
- * When running locally without a valid API key (for example, during development
- * or in CI where the OpenAI API cannot be reached), we mock the minimal
- * portion of the OpenAI library used in this handler. The mock returns a
- * predictable topic and an asynchronous generator that yields a simple dad
- * joke character by character. To enable the mock, either set the
- * environment variable MOCK_OPENAI to "true" or omit API_KEY entirely.
- */
-let openai;
-if (process.env.MOCK_OPENAI === 'true' || !process.env.API_KEY) {
-  // Read the list of dad jokes once so we can serve a random one when mocking
-  const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt');
-  const jokes = fs
-    .readFileSync(jokesPath, 'utf-8')
-    .split('\n\n')
-    .filter(Boolean);
-
-  // Define a mock responses API that mirrors the interface used below
-  openai = {
-    responses: {
-      /**
-       * Mock implementation of `responses.create`.
-       * When called without streaming, returns a dummy value (not used in this implementation).
-       * When called with streaming enabled, returns an async generator that yields a
-       * dad joke character by character from the local jokes file.
-       */
-      async create({ stream }) {
-        if (!stream) {
-          // No streaming call should be made without stream in this implementation
-          return { output_text: '' };
-        }
-        // Select a random joke from the dataset
-        const joke = jokes[Math.floor(Math.random() * jokes.length)];
-        async function* generator() {
-          for (const char of joke) {
-            // Wait a tiny bit between characters to better simulate streaming
-            await new Promise((resolve) => setTimeout(resolve, 5));
-            yield { delta: char };
-          }
-        }
-        return generator();
-      }
-    }
-  };
-} else {
-  openai = new OpenAI({
-    apiKey: process.env.API_KEY
-  });
-}
-
-const getRandomJoke = () => {
-  const jokesPath = path.join(process.cwd(), 'data', 'dad_jokes.txt');
-  const jokes = fs.readFileSync(jokesPath, 'utf-8').split('\n\n').filter(Boolean);
-  return jokes[Math.floor(Math.random() * jokes.length)];
-};
+const openai = getOpenAIClient();
 
 export default async function handler(req, res) {
   // Configure Server-Sent Events headers
@@ -94,7 +38,7 @@ export default async function handler(req, res) {
     res.write('data: [DONE]\n\n');
     res.end();
   } catch (error) {
-    const joke = getRandomJoke();
+    const joke = getRandomLocalJoke();
     res.write(`data: ${joke}\n\n`);
     res.write('data: [DONE]\n\n');
     res.end();

--- a/pages/api/ratings.js
+++ b/pages/api/ratings.js
@@ -1,0 +1,205 @@
+import { BlobNotFoundError, head, put } from '@vercel/blob'
+
+const BLOB_PREFIX = 'groan-ratings'
+const DEFAULT_COUNTS = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+const memoryStore = globalThis.__groanRatingsStore || new Map()
+if (!globalThis.__groanRatingsStore) {
+  globalThis.__groanRatingsStore = memoryStore
+}
+
+const blobToken = process.env.DAD_READ_WRITE_TOKEN
+const blobConfigured = Boolean(blobToken)
+
+function buildDefaultStats(overrides = {}) {
+  return {
+    counts: { ...DEFAULT_COUNTS },
+    totalRatings: 0,
+    average: 0,
+    ratings: [],
+    ...overrides
+  }
+}
+
+function normalizeStats(stats = {}) {
+  const counts = { ...DEFAULT_COUNTS, ...(stats.counts || {}) }
+  const totalRatings = Number(stats.totalRatings || 0)
+  const average = Number(stats.average || 0)
+  const ratings = Array.isArray(stats.ratings)
+    ? stats.ratings.map((entry) => {
+        const rating = Number(entry?.rating)
+        if (!Number.isFinite(rating)) {
+          return null
+        }
+        const normalized = {
+          rating,
+          submittedAt: entry?.submittedAt || entry?.timestamp || null
+        }
+        if (entry?.joke && typeof entry.joke === 'string') {
+          normalized.joke = entry.joke
+        }
+        if (!normalized.submittedAt) {
+          normalized.submittedAt = new Date().toISOString()
+        }
+        return normalized
+      }).filter(Boolean)
+    : []
+
+  const normalizedStats = {
+    ...stats,
+    counts,
+    totalRatings,
+    average,
+    ratings
+  }
+  if (normalizedStats.date) {
+    normalizedStats.date = `${normalizedStats.date}`
+  }
+  if (normalizedStats.jokeId) {
+    normalizedStats.jokeId = `${normalizedStats.jokeId}`
+  }
+  if (normalizedStats.joke && typeof normalizedStats.joke !== 'string') {
+    delete normalizedStats.joke
+  }
+  return normalizedStats
+}
+
+function getDateKey(input) {
+  if (typeof input === 'string' && DATE_REGEX.test(input)) {
+    return input
+  }
+  const now = new Date()
+  return now.toISOString().slice(0, 10)
+}
+
+function getStorageKey(dateKey, jokeId) {
+  return `${dateKey}:${jokeId}`
+}
+
+function getBlobPath(dateKey, jokeId) {
+  return `${BLOB_PREFIX}/${dateKey}/${jokeId}.json`
+}
+
+async function readStats(jokeId, dateKey) {
+  if (blobConfigured) {
+    const path = getBlobPath(dateKey, jokeId)
+    try {
+      const metadata = await head(path, { token: blobToken })
+      const response = await fetch(metadata.downloadUrl)
+      if (!response.ok) {
+        throw new Error('Unable to download ratings data')
+      }
+      const payload = await response.json()
+      const normalized = normalizeStats(payload)
+      if (!normalized.date) {
+        normalized.date = dateKey
+      }
+      if (!normalized.jokeId) {
+        normalized.jokeId = jokeId
+      }
+      return normalized
+    } catch (error) {
+      if (error instanceof BlobNotFoundError || error?.name === 'BlobNotFoundError') {
+        return buildDefaultStats({ date: dateKey, jokeId })
+      }
+      throw error
+    }
+  }
+  const key = getStorageKey(dateKey, jokeId)
+  return memoryStore.get(key) || buildDefaultStats({ date: dateKey, jokeId })
+}
+
+async function writeStats(jokeId, dateKey, stats) {
+  const payload = normalizeStats({ ...stats, date: dateKey, jokeId, updatedAt: new Date().toISOString() })
+  if (blobConfigured) {
+    const path = getBlobPath(dateKey, jokeId)
+    await put(path, JSON.stringify(payload), {
+      access: 'public',
+      contentType: 'application/json',
+      cacheControl: 'no-store',
+      token: blobToken
+    })
+    return payload
+  }
+  const key = getStorageKey(dateKey, jokeId)
+  memoryStore.set(key, payload)
+  return payload
+}
+
+function validateRating(value) {
+  const rating = Number(value)
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    return null
+  }
+  return rating
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const { jokeId, date: requestedDate } = req.query
+    if (!jokeId || typeof jokeId !== 'string') {
+      res.status(400).json({ error: 'Missing jokeId' })
+      return
+    }
+    const dateKey = getDateKey(Array.isArray(requestedDate) ? requestedDate[0] : requestedDate)
+    try {
+      const stats = await readStats(jokeId, dateKey)
+      res.status(200).json(stats)
+    } catch (error) {
+      res.status(500).json({ error: 'Unable to load ratings' })
+    }
+    return
+  }
+
+  if (req.method === 'POST') {
+    const { jokeId, rating, joke, date: requestedDate } = req.body || {}
+    if (!jokeId || typeof jokeId !== 'string') {
+      res.status(400).json({ error: 'Missing jokeId' })
+      return
+    }
+    const parsedRating = validateRating(rating)
+    if (!parsedRating) {
+      res.status(422).json({ error: 'Rating must be an integer between 1 and 5' })
+      return
+    }
+    const dateKey = getDateKey(requestedDate)
+
+    try {
+      const stats = await readStats(jokeId, dateKey)
+      const counts = { ...stats.counts }
+      counts[parsedRating] = (counts[parsedRating] || 0) + 1
+      const totalRatings = Object.values(counts).reduce((acc, val) => acc + val, 0)
+      const totalScore = Object.entries(counts).reduce(
+        (acc, [score, count]) => acc + Number(score) * count,
+        0
+      )
+      const average = totalRatings === 0 ? 0 : Number((totalScore / totalRatings).toFixed(2))
+      const history = Array.isArray(stats.ratings) ? [...stats.ratings] : []
+      const entry = { rating: parsedRating, submittedAt: new Date().toISOString() }
+      if (joke && typeof joke === 'string') {
+        entry.joke = joke
+      }
+      history.push(entry)
+
+      const updatedStats = {
+        counts,
+        totalRatings,
+        average,
+        ratings: history,
+        joke: typeof joke === 'string' ? joke : stats.joke,
+        date: dateKey,
+        jokeId
+      }
+
+      const persisted = await writeStats(jokeId, dateKey, updatedStats)
+      res.status(200).json(persisted)
+    } catch (error) {
+      res.status(500).json({ error: 'Unable to save rating' })
+    }
+    return
+  }
+
+  res.setHeader('Allow', ['GET', 'POST'])
+  res.status(405).end('Method Not Allowed')
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,20 @@ import Header from '../components/Header'
 import Spinner from '../components/Spinner'
 import { parseStream } from '../lib/parseJokeStream'
 
+const defaultRatingStats = {
+  counts: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
+  average: 0,
+  totalRatings: 0
+}
+
+function normalizeStats(stats = {}) {
+  return {
+    counts: { ...defaultRatingStats.counts, ...(stats.counts || {}) },
+    average: Number(stats.average || 0),
+    totalRatings: Number(stats.totalRatings || 0)
+  }
+}
+
 
 class OpenAIData extends React.Component {
   constructor(props) {
@@ -17,14 +31,198 @@ class OpenAIData extends React.Component {
       answer: "",
       questionTokens: [],
       answerTokens: [],
-      pendingQuestion: ''
+      pendingQuestion: '',
+      ratingStats: { ...defaultRatingStats },
+      userRating: null,
+      isSubmittingRating: false,
+      ratingError: null,
+      hasSubmittedRating: false,
+      currentJokeId: null,
+      currentJokeText: '',
+      currentDateKey: new Date().toISOString().slice(0, 10),
+      jokeMode: 'live',
+      dailyContext: null
     };
     this.eventSource = null;
   }
 
   componentDidMount() {
-    // Load the initial joke when the component mounts
+    const envDefault =
+      typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_DEFAULT_JOKE_MODE : null;
+    const defaultMode = envDefault === 'live' ? 'live' : 'daily';
+    let savedMode = null;
+    try {
+      savedMode = window.localStorage.getItem('jokeMode');
+    } catch (error) {
+      savedMode = null;
+    }
+    const mode = savedMode === 'live' || savedMode === 'daily' ? savedMode : defaultMode;
+    this.setState({ jokeMode: mode, currentDateKey: this.getDateKey() }, () => {
+      this.loadJokeForMode(mode);
+    });
+  }
+
+  componentWillUnmount() {
+    if (this.eventSource) {
+      this.eventSource.close();
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      this.state.isComplete &&
+      (prevState.questionTokens !== this.state.questionTokens ||
+        prevState.answerTokens !== this.state.answerTokens ||
+        prevState.isComplete !== this.state.isComplete)
+    ) {
+      this.prepareJokeMetadata();
+    }
+  }
+
+  getDateKey = () => {
+    const now = new Date();
+    return now.toISOString().slice(0, 10);
+  };
+
+  prepareJokeMetadata = () => {
+    const {
+      questionTokens,
+      answerTokens,
+      currentJokeId,
+      currentJokeText,
+      jokeMode,
+      dailyContext,
+      currentDateKey
+    } = this.state;
+    const question = questionTokens.join(' ').trim();
+    const answer = answerTokens.join(' ').trim();
+    if (!question && !answer) {
+      return;
+    }
+    const parts = [];
+    if (question) parts.push(question);
+    if (answer) parts.push(answer);
+    const jokeText = parts.join(' || ').trim();
+    const dateKey =
+      (jokeMode === 'daily' ? dailyContext?.date : currentDateKey) || this.getDateKey();
+
+    let jokeId = currentJokeId;
+    let shouldFetchStats = false;
+
+    if (jokeMode === 'daily') {
+      const desiredId = `daily-${dateKey}`;
+      if (desiredId !== jokeId) {
+        jokeId = desiredId;
+        shouldFetchStats = true;
+      }
+    } else if (!jokeId || !jokeId.startsWith('live-')) {
+      jokeId = this.createLiveJokeId(dateKey);
+      shouldFetchStats = true;
+    }
+
+    if (jokeId === currentJokeId && jokeText === currentJokeText) {
+      return;
+    }
+
+    this.setState(
+      (prevState) => ({
+        currentJokeId: jokeId,
+        currentJokeText: jokeText,
+        ratingStats: shouldFetchStats ? { ...defaultRatingStats } : prevState.ratingStats,
+        userRating: shouldFetchStats ? null : prevState.userRating,
+        isSubmittingRating: false,
+        ratingError: shouldFetchStats ? null : prevState.ratingError,
+        hasSubmittedRating: shouldFetchStats ? false : prevState.hasSubmittedRating,
+        currentDateKey: dateKey
+      }),
+      () => {
+        if (shouldFetchStats || jokeId !== currentJokeId) {
+          this.fetchRatingStats(jokeId, dateKey);
+        }
+      }
+    );
+  }
+
+  loadJokeForMode = (mode) => {
+    if (mode === 'daily') {
+      this.fetchDailyJoke();
+      return;
+    }
     this.fetchJoke();
+  }
+
+  createLiveJokeId = (dateKey) => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `live-${dateKey}-${crypto.randomUUID()}`;
+    }
+    return `live-${dateKey}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  fetchRatingStats = async (jokeId, dateKey) => {
+    try {
+      const params = new URLSearchParams({ jokeId });
+      if (dateKey) {
+        params.set('date', dateKey);
+      }
+      const response = await fetch(`/api/ratings?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error('Unable to load ratings');
+      }
+      const data = await response.json();
+      this.setState({
+        ratingStats: normalizeStats(data),
+        ratingError: null,
+        currentDateKey: data?.date || dateKey || this.getDateKey()
+      });
+    } catch (error) {
+      this.setState({
+        ratingError: error,
+        ratingStats: { ...defaultRatingStats }
+      });
+    }
+  }
+
+  handleGroanClick = async (value) => {
+    const {
+      currentJokeId,
+      currentJokeText,
+      hasSubmittedRating,
+      isSubmittingRating,
+      currentDateKey
+    } = this.state;
+    if (!currentJokeId || hasSubmittedRating || isSubmittingRating) {
+      return;
+    }
+    this.setState({ userRating: value, isSubmittingRating: true, ratingError: null });
+    try {
+      const response = await fetch('/api/ratings', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          jokeId: currentJokeId,
+          rating: value,
+          joke: currentJokeText,
+          date: currentDateKey
+        })
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.error || 'Unable to save rating');
+      }
+      const data = await response.json();
+      this.setState({
+        ratingStats: normalizeStats(data),
+        hasSubmittedRating: true,
+        ratingError: null,
+        currentDateKey: data?.date || currentDateKey
+      });
+    } catch (error) {
+      this.setState({ ratingError: error });
+    } finally {
+      this.setState({ isSubmittingRating: false });
+    }
   }
 
   fetchJoke = () => {
@@ -41,7 +239,16 @@ class OpenAIData extends React.Component {
       answer: '',
       questionTokens: [],
       answerTokens: [],
-      pendingQuestion: ''
+      pendingQuestion: '',
+      ratingStats: { ...defaultRatingStats },
+      userRating: null,
+      isSubmittingRating: false,
+      ratingError: null,
+      hasSubmittedRating: false,
+      currentJokeId: null,
+      currentJokeText: '',
+      currentDateKey: this.getDateKey(),
+      dailyContext: null
     });
 
     // Establish an EventSource connection to receive SSEs from the backend
@@ -82,6 +289,67 @@ class OpenAIData extends React.Component {
     };
   }
 
+  fetchDailyJoke = async () => {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    this.setState({
+      error: null,
+      isLoaded: false,
+      isComplete: false,
+      question: '',
+      answer: '',
+      questionTokens: [],
+      answerTokens: [],
+      pendingQuestion: '',
+      ratingStats: { ...defaultRatingStats },
+      userRating: null,
+      isSubmittingRating: false,
+      ratingError: null,
+      hasSubmittedRating: false,
+      currentJokeId: null,
+      currentJokeText: '',
+      currentDateKey: this.getDateKey(),
+      dailyContext: null
+    });
+    try {
+      const res = await fetch('/api/daily-joke');
+      if (!res.ok) {
+        throw new Error('Unable to load the daily joke');
+      }
+      const data = await res.json();
+      const initialState = {
+        question: '',
+        answer: '',
+        questionTokens: [],
+        answerTokens: [],
+        pendingQuestion: ''
+      };
+      const parsed = parseStream(data.joke || '', initialState);
+      this.setState(
+        {
+          ...parsed,
+          isLoaded: true,
+          isComplete: true,
+          error: null,
+          dailyContext: data.context || null,
+          currentDateKey: data?.context?.date || this.getDateKey()
+        },
+        () => {
+          this.prepareJokeMetadata();
+        }
+      );
+    } catch (error) {
+      this.setState({
+        error,
+        isLoaded: true,
+        isComplete: true,
+        currentDateKey: this.getDateKey()
+      });
+    }
+  }
+
   loadFallbackJoke = async () => {
     try {
       const res = await fetch('/api/random-joke');
@@ -98,25 +366,48 @@ class OpenAIData extends React.Component {
         ...parsed,
         isLoaded: true,
         isComplete: true,
-        error: null
+        error: null,
+        currentDateKey: this.getDateKey()
       });
     } catch (error) {
       this.setState({
         isLoaded: true,
         isComplete: true,
-        error
+        error,
+        currentDateKey: this.getDateKey()
       });
     }
   }
 
-  componentWillUnmount() {
-    if (this.eventSource) {
-      this.eventSource.close();
+  handleModeChange = (mode) => {
+    if (mode === this.state.jokeMode) {
+      return;
     }
+    try {
+      window.localStorage.setItem('jokeMode', mode);
+    } catch (error) {
+      // Ignore storage failures
+    }
+    this.setState({ jokeMode: mode, currentDateKey: this.getDateKey() }, () => {
+      this.loadJokeForMode(mode);
+    });
   }
 
   render() {
-    const { error, isLoaded, isComplete, questionTokens, answerTokens } = this.state;
+    const {
+      error,
+      isLoaded,
+      isComplete,
+      questionTokens,
+      answerTokens,
+      ratingStats,
+      userRating,
+      isSubmittingRating,
+      ratingError,
+      hasSubmittedRating,
+      jokeMode,
+      dailyContext
+    } = this.state;
     if (error) {
       return <div>Error Loading: {error.message}</div>;
     }
@@ -127,6 +418,22 @@ class OpenAIData extends React.Component {
       <div className={styles.jokeContainer}>
         {/* Update the header to be a bit more playful */}
         <h2 className={styles.jokeHeader}>Dad Joke of the Day (Guaranteed to Make You Groan)</h2>
+        <div className={styles.modeToggle}>
+          <button
+            type="button"
+            className={`${styles.modeButton} ${jokeMode === 'live' ? styles.modeButtonActive : ''}`}
+            onClick={() => this.handleModeChange('live')}
+          >
+            Live Stream
+          </button>
+          <button
+            type="button"
+            className={`${styles.modeButton} ${jokeMode === 'daily' ? styles.modeButtonActive : ''}`}
+            onClick={() => this.handleModeChange('daily')}
+          >
+            Joke of the Day
+          </button>
+        </div>
         {questionTokens.length > 0 && (
           <p className={styles.question}>
             {questionTokens.map((t, i) => (
@@ -142,9 +449,78 @@ class OpenAIData extends React.Component {
           </p>
         )}
         {isComplete && (
-          <button className={styles.newJokeButton} onClick={this.fetchJoke}>
-            New Joke
+          <>
+            <div className={styles.ratingSection}>
+              <p className={styles.ratingPrompt}>How many groans does this joke deserve?</p>
+              <div className={styles.groanButtonGroup}>
+                {[1, 2, 3, 4, 5].map((value) => {
+                  const isActive = userRating ? value <= userRating : false;
+                  const buttonClass = `${styles.groanButton} ${isActive ? styles.groanButtonActive : ''}`;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      className={buttonClass}
+                      onClick={() => this.handleGroanClick(value)}
+                      disabled={isSubmittingRating || hasSubmittedRating}
+                      aria-label={`${value} groan${value === 1 ? '' : 's'}`}
+                    >
+                      {value}
+                    </button>
+                  );
+                })}
+              </div>
+              <div className={styles.ratingSummary}>
+                {ratingStats.totalRatings > 0 ? (
+                  <p>
+                    Average rating: <strong>{ratingStats.average}</strong> groans ·{' '}
+                    {ratingStats.totalRatings} total rating{ratingStats.totalRatings === 1 ? '' : 's'}
+                  </p>
+                ) : (
+                  <p>Be the first to rate this groaner.</p>
+                )}
+                {hasSubmittedRating && (
+                  <p className={styles.ratingThanks}>Thanks for letting us know how much you groaned!</p>
+                )}
+                {ratingError && (
+                  <p className={styles.ratingError}>We couldn&apos;t save your rating. Please try again.</p>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+        {isComplete && (
+          <button
+            className={styles.newJokeButton}
+            onClick={jokeMode === 'daily' ? this.fetchDailyJoke : this.fetchJoke}
+          >
+            {jokeMode === 'daily' ? 'Reload Daily Joke' : 'New Joke'}
           </button>
+        )}
+        {jokeMode === 'daily' && dailyContext && (
+          <div className={styles.dailyContext}>
+            <h3>Why today?</h3>
+            {dailyContext.year ? (
+              <p>
+                In {dailyContext.year}, {dailyContext.text}
+              </p>
+            ) : (
+              <p>{dailyContext.text}</p>
+            )}
+            {dailyContext.summary && (
+              <p className={styles.dailySummary}>{dailyContext.summary}</p>
+            )}
+            {dailyContext.source && (
+              <a
+                className={styles.dailyLink}
+                href={dailyContext.source}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Read more about today&apos;s event
+              </a>
+            )}
+          </div>
         )}
       </div>
     );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -252,10 +252,135 @@
   transform: translateY(-2px);
 }
 
+.modeToggle {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.modeButton {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-dark);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.modeButton:hover {
+  border-color: var(--color-primary);
+  transform: translateY(-1px);
+}
+
+.modeButtonActive {
+  background: var(--color-primary);
+  color: #000;
+  border-color: var(--color-primary);
+  font-weight: 600;
+}
+
+.dailyContext {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--color-border-dark);
+  line-height: 1.5;
+}
+
+.dailyContext h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.25rem;
+}
+
+.dailySummary {
+  margin-top: 0.5rem;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dailyLink {
+  display: inline-block;
+  margin-top: 0.75rem;
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.dailyLink:hover,
+.dailyLink:focus {
+  color: #f7dc6f;
+}
+
 /* Simple fade-in utility for question and answer text */
 .fadeIn {
   opacity: 0;
   animation: fadeIn 0.5s ease-in forwards;
+}
+
+.ratingSection {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border-dark);
+  border-radius: 8px;
+  background-color: rgba(255, 255, 255, 0.03);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+}
+
+.ratingPrompt {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.groanButtonGroup {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.groanButton {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface-dark);
+  color: var(--color-text);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.groanButton:hover:not(:disabled) {
+  transform: translateY(-2px);
+  border-color: var(--color-primary);
+}
+
+.groanButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.groanButtonActive {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #000;
+  font-weight: 700;
+}
+
+.ratingSummary p {
+  margin: 0.25rem 0;
+}
+
+.ratingThanks {
+  color: #2ecc71;
+  font-weight: 600;
+}
+
+.ratingError {
+  color: #e74c3c;
+  font-weight: 600;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- rename the blob storage token configuration to DAD_READ_WRITE_TOKEN and pass it through blob read/write helpers
- default the app to daily joke mode while letting users toggle to live streaming, tracking the active date for ratings
- generate per-day IDs for live jokes, send the date with rating requests, and document the new defaults in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b0761fd483288f20acebbd5ba8f4