### PR TITLE
Improve daily joke humor and blob overwrite handling

### DIFF
--- a/lib/generatePrompt.mjs
+++ b/lib/generatePrompt.mjs
@@ -73,15 +73,24 @@ function buildDailyPrompt(event) {
     text,
     title,
     summary,
-    source
+    source,
+    comedicAngle,
+    selectionReason
   } = event;
   const description = summary || text || title;
   const sourceLine = source ? `Use this reference for context: ${source}.` : '';
+  const angleLine = comedicAngle
+    ? `Lean into this comedic angle: ${comedicAngle}.`
+    : selectionReason
+    ? `Let this reasoning guide your humor: ${selectionReason}.`
+    : '';
   return [
     'Craft a dad joke that feels timely for today. Use the details below as inspiration and weave them into the setup or punchline in a playful way:',
     `Event: ${description}`,
     year ? `Happened in: ${year}` : '',
+    title && !description.includes(title) ? `Title: ${title}` : '',
     sourceLine,
+    angleLine,
     'Keep the humor groan-worthy but warm-hearted, and make sure the joke makes it clear why the event or date matters.',
     'Avoid using special characters or symbols; respond with plain text only.',
     'Return the joke on exactly two lines labeled like:',

--- a/pages/api/daily-joke.js
+++ b/pages/api/daily-joke.js
@@ -72,8 +72,8 @@ async function writeCachedJoke(dateKey, payload) {
   memoryStore.set(dateKey, payload)
 }
 
-async function fetchOnThisDayEvent(dateKey) {
-  const [year, month, day] = dateKey.split('-')
+async function fetchOnThisDayEvents(dateKey) {
+  const [, month, day] = dateKey.split('-')
   const endpoint = `https://en.wikipedia.org/api/rest_v1/feed/onthisday/events/${Number(
     month
   )}/${Number(day)}`
@@ -86,17 +86,74 @@ async function fetchOnThisDayEvent(dateKey) {
   if (events.length === 0) {
     throw new Error('No events available for today')
   }
-  // Deterministically pick an event based on the year and index so all deployments agree
-  const indexSeed = Number(year) + Number(month) + Number(day)
-  const event = events[indexSeed % events.length]
-  const page = Array.isArray(event?.pages) ? event.pages[0] : null
-  const source = page?.content_urls?.desktop?.page || page?.content_urls?.mobile?.page
-  return {
-    year: event?.year || null,
-    text: event?.text || '',
-    title: event?.title || page?.titles?.normalized || '',
-    summary: page?.extract || '',
-    source: source || null
+  return events
+    .map((event) => {
+      const page = Array.isArray(event?.pages) ? event.pages[0] : null
+      const source = page?.content_urls?.desktop?.page || page?.content_urls?.mobile?.page
+      const summary = page?.extract || ''
+      return {
+        year: event?.year || null,
+        text: event?.text || '',
+        title: event?.title || page?.titles?.normalized || '',
+        summary,
+        source: source || null
+      }
+    })
+    .filter((event) => event.text || event.summary || event.title)
+}
+
+async function selectFunniestEvent(events, openai) {
+  if (!events.length) {
+    throw new Error('No events provided to select from')
+  }
+
+  if (openai.__mock) {
+    return { event: events[0], reasoning: 'Mock client selected the first event.', comedicAngle: null }
+  }
+
+  const shortlist = events.slice(0, 12)
+  const formattedEvents = shortlist
+    .map((event, index) => {
+      const pieces = [
+        `Event ${index}:`,
+        event.year ? `Year: ${event.year}.` : 'Year: Unknown.',
+        event.title ? `Title: ${event.title}.` : '',
+        event.text ? `Detail: ${event.text}` : '',
+        event.summary ? `Summary: ${event.summary.slice(0, 320)}` : ''
+      ].filter(Boolean)
+      return pieces.join(' ')
+    })
+    .join('\n')
+
+  const selectionPrompt = [
+    'You are the head writer for a dad-joke newsletter. Review the historical events below and pick the one with the richest comedic potential for a warm, groan-worthy joke.',
+    'Respond with a JSON object that includes:',
+    '- "index": the 0-based index of the chosen event from the list.',
+    '- "reason": a short explanation for why it is funny.',
+    '- "comedicAngle": a quick note on the angle or detail to emphasize.',
+    'Keep the response under 60 words.',
+    'Events:',
+    formattedEvents
+  ].join('\n')
+
+  try {
+    const response = await openai.responses.create({
+      model: 'gpt-4o-mini',
+      input: selectionPrompt,
+      temperature: 0.6,
+      response_format: { type: 'json_object' }
+    })
+    const text = extractTextFromResponse(response)
+    const parsed = JSON.parse(text || '{}')
+    const index = Number.isInteger(parsed.index) ? parsed.index : 0
+    const safeIndex = Math.max(0, Math.min(shortlist.length - 1, index))
+    return {
+      event: shortlist[safeIndex],
+      reasoning: typeof parsed.reason === 'string' ? parsed.reason : '',
+      comedicAngle: typeof parsed.comedicAngle === 'string' ? parsed.comedicAngle : ''
+    }
+  } catch (error) {
+    return { event: events[0], reasoning: '', comedicAngle: '' }
   }
 }
 
@@ -142,9 +199,15 @@ export default async function handler(req, res) {
   }
 
   try {
-    const event = await fetchOnThisDayEvent(dateKey)
-    const prompt = generatePrompt({ mode: 'daily', event })
+    const events = await fetchOnThisDayEvents(dateKey)
     const openai = getOpenAIClient()
+    const selection = await selectFunniestEvent(events, openai)
+    const selectedEvent = {
+      ...selection.event,
+      comedicAngle: selection.comedicAngle,
+      selectionReason: selection.reasoning
+    }
+    const prompt = generatePrompt({ mode: 'daily', event: selectedEvent })
     const response = await openai.responses.create({
       model: 'gpt-4o-mini',
       input: prompt,
@@ -156,10 +219,13 @@ export default async function handler(req, res) {
       joke: joke || getRandomLocalJoke(),
       context: {
         date: dateKey,
-        year: event.year,
-        text: event.text,
-        summary: event.summary,
-        source: event.source
+        year: selectedEvent.year,
+        text: selectedEvent.text,
+        summary: selectedEvent.summary,
+        source: selectedEvent.source,
+        title: selectedEvent.title || null,
+        angle: selection.comedicAngle || null,
+        reason: selection.reasoning || null
       }
     }
     await writeCachedJoke(dateKey, payload)
@@ -172,7 +238,10 @@ export default async function handler(req, res) {
         year: null,
         text: 'Unable to fetch on-this-day facts, serving a timeless dad joke instead.',
         summary: '',
-        source: null
+        source: null,
+        title: null,
+        angle: null,
+        reason: null
       }
     }
     res.status(200).json(fallback)

--- a/pages/api/ratings.js
+++ b/pages/api/ratings.js
@@ -144,7 +144,8 @@ async function writeStats(jokeId, dateKey, stats) {
         access: 'public',
         contentType: 'application/json',
         cacheControl: 'no-store',
-        token: blobToken
+        token: blobToken,
+        allowOverwrite: true
       })
       logStorage('Persisted ratings to blob storage', { path })
       return payload


### PR DESCRIPTION
## Summary
- allow ratings blobs to be overwritten so daily votes keep persisting
- evaluate multiple "on this day" events with OpenAI to pick the funniest one
- feed the chosen comedic angle into the daily joke prompt and cache metadata for the UI

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e5c73c40308328962e140a8df2f5e4