### PR TITLE
Add dashboard with aggregated joke insights

### DIFF
--- a/lib/ratingsStorage.js
+++ b/lib/ratingsStorage.js
@@ -1,0 +1,555 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { randomUUID } from 'crypto'
+
+const DEFAULT_COUNTS = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+const USER_DEFINED_BASE_DIR = process.env.RATINGS_STORAGE_DIR
+  ? path.resolve(process.env.RATINGS_STORAGE_DIR)
+  : null
+const DEFAULT_BASE_DIR = path.join(process.cwd(), 'data', 'ratings')
+const FALLBACK_BASE_DIR = path.join(
+  process.env.TMPDIR || '/tmp',
+  'joshkurzsite',
+  'ratings'
+)
+
+let resolvedBaseDir = null
+let resolvingBaseDirPromise = null
+
+async function ensureDir(dirPath) {
+  try {
+    await fs.mkdir(dirPath, { recursive: true })
+  } catch (error) {
+    if (error?.code !== 'EEXIST') {
+      throw error
+    }
+  }
+}
+
+async function getBaseDir() {
+  if (resolvedBaseDir) {
+    return resolvedBaseDir
+  }
+
+  if (!resolvingBaseDirPromise) {
+    const candidateDirs = [
+      USER_DEFINED_BASE_DIR,
+      DEFAULT_BASE_DIR,
+      FALLBACK_BASE_DIR
+    ].filter(Boolean)
+
+    resolvingBaseDirPromise = (async () => {
+      for (const candidate of candidateDirs) {
+        try {
+          await ensureDir(candidate)
+          if (candidate !== DEFAULT_BASE_DIR) {
+            console.info('[ratings] Using alternate storage directory', {
+              dirPath: candidate
+            })
+          }
+          resolvedBaseDir = candidate
+          return candidate
+        } catch (error) {
+          console.warn('[ratings] Unable to use storage directory', {
+            dirPath: candidate,
+            error
+          })
+        }
+      }
+
+      throw new Error('Unable to locate a writable directory for ratings storage')
+    })()
+  }
+
+  try {
+    return await resolvingBaseDirPromise
+  } finally {
+    resolvingBaseDirPromise = null
+  }
+}
+
+function getMode(value) {
+  return value === 'daily' ? 'daily' : 'live'
+}
+
+function buildDefaultStats(overrides = {}) {
+  return {
+    counts: { ...DEFAULT_COUNTS },
+    totalRatings: 0,
+    average: 0,
+    ratings: [],
+    ...overrides
+  }
+}
+
+function normalizeEntry(entry = {}) {
+  const rating = Number(entry.rating)
+  if (!Number.isFinite(rating)) {
+    return null
+  }
+  const normalized = {
+    rating,
+    submittedAt: entry.submittedAt || entry.timestamp || new Date().toISOString()
+  }
+  if (entry.joke && typeof entry.joke === 'string') {
+    normalized.joke = entry.joke
+  }
+  if (entry.mode) {
+    normalized.mode = entry.mode
+  }
+  if (entry.date) {
+    normalized.date = entry.date
+  }
+  if (entry.jokeId) {
+    normalized.jokeId = entry.jokeId
+  }
+  return normalized
+}
+
+function aggregateEntries(entries, { dateKey, jokeId, mode }) {
+  if (!entries.length) {
+    return buildDefaultStats({ date: dateKey, jokeId, mode })
+  }
+  const counts = { ...DEFAULT_COUNTS }
+  const normalizedEntries = []
+  for (const entry of entries) {
+    const normalized = normalizeEntry(entry)
+    if (!normalized) {
+      continue
+    }
+    counts[normalized.rating] = (counts[normalized.rating] || 0) + 1
+    normalizedEntries.push(normalized)
+  }
+  const totalRatings = normalizedEntries.length
+  const totalScore = normalizedEntries.reduce(
+    (acc, entry) => acc + entry.rating,
+    0
+  )
+  const average = totalRatings === 0 ? 0 : Number((totalScore / totalRatings).toFixed(2))
+  return {
+    counts,
+    totalRatings,
+    average,
+    ratings: normalizedEntries.sort((a, b) => {
+      const aTime = new Date(a.submittedAt).getTime()
+      const bTime = new Date(b.submittedAt).getTime()
+      return aTime - bTime
+    }),
+    date: dateKey,
+    jokeId,
+    mode
+  }
+}
+
+function getDateKey(input) {
+  if (typeof input === 'string' && DATE_REGEX.test(input)) {
+    return input
+  }
+  const now = new Date()
+  return now.toISOString().slice(0, 10)
+}
+
+async function readJson(filePath) {
+  try {
+    const content = await fs.readFile(filePath, 'utf8')
+    return JSON.parse(content)
+  } catch (error) {
+    console.error('[ratings] Failed to read review file', { filePath, error })
+    return null
+  }
+}
+
+async function readEntriesFromDir(dirPath, filterFn) {
+  let entries = []
+  try {
+    const files = await fs.readdir(dirPath)
+    for (const file of files) {
+      if (!file.endsWith('.json')) {
+        continue
+      }
+      const filePath = path.join(dirPath, file)
+      const payload = await readJson(filePath)
+      if (!payload) {
+        continue
+      }
+      if (!filterFn || filterFn(payload)) {
+        entries.push(payload)
+      }
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      console.error('[ratings] Unable to list reviews directory', { dirPath, error })
+    }
+  }
+  return entries
+}
+
+async function readStats({ mode, jokeId, dateKey }) {
+  const baseDir = await getBaseDir()
+  if (mode === 'daily') {
+    const dirPath = path.join(baseDir, 'daily', dateKey)
+    const entries = await readEntriesFromDir(dirPath, (payload) => payload?.jokeId === jokeId)
+    return aggregateEntries(entries, { dateKey, jokeId, mode })
+  }
+  const dirPath = path.join(baseDir, 'live', jokeId)
+  const entries = await readEntriesFromDir(dirPath)
+  return aggregateEntries(entries, { dateKey, jokeId, mode })
+}
+
+async function writeReview({ mode, jokeId, dateKey, rating, joke }) {
+  const baseDir = await getBaseDir()
+  const submittedAt = new Date().toISOString()
+  const payload = {
+    jokeId,
+    date: dateKey,
+    rating,
+    submittedAt,
+    mode,
+    ...(joke ? { joke } : {})
+  }
+
+  if (mode === 'daily') {
+    const dirPath = path.join(baseDir, 'daily', dateKey)
+    await ensureDir(dirPath)
+    const fileName = `${jokeId}-${submittedAt.replace(/[:.]/g, '-')}-${randomUUID()}.json`
+    const filePath = path.join(dirPath, fileName)
+    await fs.writeFile(filePath, JSON.stringify(payload, null, 2), 'utf8')
+    return
+  }
+
+  const dirPath = path.join(baseDir, 'live', jokeId)
+  await ensureDir(dirPath)
+  const fileName = `${submittedAt.replace(/[:.]/g, '-')}-${randomUUID()}.json`
+  const filePath = path.join(dirPath, fileName)
+  await fs.writeFile(filePath, JSON.stringify(payload, null, 2), 'utf8')
+}
+
+async function readAllRatingEntries() {
+  const baseDir = await getBaseDir()
+  const allEntries = []
+
+  const dailyRoot = path.join(baseDir, 'daily')
+  try {
+    const dateDirs = await fs.readdir(dailyRoot, { withFileTypes: true })
+    for (const dirent of dateDirs) {
+      if (!dirent.isDirectory()) {
+        continue
+      }
+      const dateKey = dirent.name
+      const dirPath = path.join(dailyRoot, dateKey)
+      const payloads = await readEntriesFromDir(dirPath)
+      for (const payload of payloads) {
+        const normalized = normalizeEntry({
+          ...payload,
+          mode: 'daily',
+          date: payload?.date || dateKey
+        })
+        if (normalized) {
+          if (!normalized.date) {
+            normalized.date = dateKey
+          }
+          normalized.mode = 'daily'
+          allEntries.push(normalized)
+        }
+      }
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      console.error('[ratings] Unable to read daily ratings directories', {
+        root: dailyRoot,
+        error
+      })
+    }
+  }
+
+  const liveRoot = path.join(baseDir, 'live')
+  try {
+    const jokeDirs = await fs.readdir(liveRoot, { withFileTypes: true })
+    for (const dirent of jokeDirs) {
+      if (!dirent.isDirectory()) {
+        continue
+      }
+      const jokeId = dirent.name
+      const dirPath = path.join(liveRoot, jokeId)
+      const payloads = await readEntriesFromDir(dirPath)
+      for (const payload of payloads) {
+        const normalized = normalizeEntry({
+          ...payload,
+          mode: 'live',
+          jokeId
+        })
+        if (normalized) {
+          normalized.mode = 'live'
+          if (!normalized.jokeId) {
+            normalized.jokeId = jokeId
+          }
+          allEntries.push(normalized)
+        }
+      }
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      console.error('[ratings] Unable to read live ratings directories', {
+        root: liveRoot,
+        error
+      })
+    }
+  }
+
+  return allEntries
+}
+
+function cloneCounts(counts) {
+  return { 1: counts[1] || 0, 2: counts[2] || 0, 3: counts[3] || 0, 4: counts[4] || 0, 5: counts[5] || 0 }
+}
+
+function safeAverage(totalScore, totalRatings) {
+  if (!totalRatings) {
+    return 0
+  }
+  return Number((totalScore / totalRatings).toFixed(2))
+}
+
+export async function summarizeRatings() {
+  const entries = await readAllRatingEntries()
+  const baseResult = {
+    totals: {
+      overallRatings: 0,
+      overallAverage: 0,
+      uniqueJokes: 0,
+      firstReviewAt: null,
+      latestReviewAt: null,
+      ratingCounts: { ...DEFAULT_COUNTS },
+      live: { totalRatings: 0, average: 0 },
+      daily: { totalRatings: 0, average: 0 }
+    },
+    ratingDistribution: {
+      overall: { ...DEFAULT_COUNTS },
+      live: { ...DEFAULT_COUNTS },
+      daily: { ...DEFAULT_COUNTS }
+    },
+    topLiveJokes: [],
+    topDailyHighlights: [],
+    highestVolumeDates: [],
+    recentRatings: []
+  }
+
+  if (!entries.length) {
+    return baseResult
+  }
+
+  const overallCounts = { ...DEFAULT_COUNTS }
+  const modeTotals = {
+    live: { counts: { ...DEFAULT_COUNTS }, totalRatings: 0, totalScore: 0 },
+    daily: { counts: { ...DEFAULT_COUNTS }, totalRatings: 0, totalScore: 0 }
+  }
+  const jokesById = new Map()
+  const ratingsByDate = new Map()
+  const uniqueJokes = new Set()
+  let totalRatings = 0
+  let totalScore = 0
+  let earliestTimestamp = null
+  let latestTimestamp = null
+
+  for (const entry of entries) {
+    const mode = entry.mode === 'daily' ? 'daily' : 'live'
+    const rating = Number(entry.rating)
+    if (!Number.isFinite(rating)) {
+      continue
+    }
+    const submittedAt = entry.submittedAt || new Date().toISOString()
+    const submittedTime = Number(new Date(submittedAt).getTime())
+    if (!Number.isNaN(submittedTime)) {
+      if (!earliestTimestamp || submittedTime < earliestTimestamp) {
+        earliestTimestamp = submittedTime
+      }
+      if (!latestTimestamp || submittedTime > latestTimestamp) {
+        latestTimestamp = submittedTime
+      }
+    }
+
+    const dateKey = entry.date
+      ? String(entry.date).slice(0, 10)
+      : new Date(submittedAt).toISOString().slice(0, 10)
+
+    totalRatings += 1
+    totalScore += rating
+    overallCounts[rating] = (overallCounts[rating] || 0) + 1
+
+    modeTotals[mode].totalRatings += 1
+    modeTotals[mode].totalScore += rating
+    modeTotals[mode].counts[rating] = (modeTotals[mode].counts[rating] || 0) + 1
+
+    const jokeId = entry.jokeId || 'unknown'
+    const jokeKey = `${mode}::${jokeId}`
+    uniqueJokes.add(jokeKey)
+    const existing = jokesById.get(jokeKey) || {
+      jokeId,
+      mode,
+      joke: entry.joke || null,
+      totalRatings: 0,
+      totalScore: 0,
+      counts: { ...DEFAULT_COUNTS },
+      firstRatedAt: submittedAt,
+      lastRatedAt: submittedAt,
+      dates: new Map()
+    }
+    existing.totalRatings += 1
+    existing.totalScore += rating
+    existing.counts[rating] = (existing.counts[rating] || 0) + 1
+    if (entry.joke && !existing.joke) {
+      existing.joke = entry.joke
+    }
+    if (Number(new Date(submittedAt).getTime()) < Number(new Date(existing.firstRatedAt).getTime())) {
+      existing.firstRatedAt = submittedAt
+    }
+    if (Number(new Date(submittedAt).getTime()) > Number(new Date(existing.lastRatedAt).getTime())) {
+      existing.lastRatedAt = submittedAt
+    }
+    if (dateKey) {
+      const dateValue = existing.dates.get(dateKey) || { count: 0, totalScore: 0 }
+      dateValue.count += 1
+      dateValue.totalScore += rating
+      existing.dates.set(dateKey, dateValue)
+    }
+    jokesById.set(jokeKey, existing)
+
+    if (dateKey) {
+      const existingDate = ratingsByDate.get(dateKey) || {
+        date: dateKey,
+        totalRatings: 0,
+        totalScore: 0,
+        counts: { ...DEFAULT_COUNTS },
+        modeBreakdown: { live: 0, daily: 0 }
+      }
+      existingDate.totalRatings += 1
+      existingDate.totalScore += rating
+      existingDate.counts[rating] = (existingDate.counts[rating] || 0) + 1
+      existingDate.modeBreakdown[mode] = (existingDate.modeBreakdown[mode] || 0) + 1
+      ratingsByDate.set(dateKey, existingDate)
+    }
+  }
+
+  const overallAverage = safeAverage(totalScore, totalRatings)
+  const liveAverage = safeAverage(modeTotals.live.totalScore, modeTotals.live.totalRatings)
+  const dailyAverage = safeAverage(modeTotals.daily.totalScore, modeTotals.daily.totalRatings)
+
+  const topLiveJokes = Array.from(jokesById.values())
+    .filter((item) => item.mode === 'live')
+    .map((item) => ({
+      jokeId: item.jokeId,
+      mode: item.mode,
+      joke: item.joke,
+      totalRatings: item.totalRatings,
+      average: safeAverage(item.totalScore, item.totalRatings),
+      counts: cloneCounts(item.counts),
+      firstRatedAt: item.firstRatedAt,
+      lastRatedAt: item.lastRatedAt
+    }))
+    .sort((a, b) => {
+      if (b.average === a.average) {
+        return b.totalRatings - a.totalRatings
+      }
+      return b.average - a.average
+    })
+    .slice(0, 5)
+
+  const topDailyHighlights = Array.from(ratingsByDate.values())
+    .filter((item) => item.modeBreakdown.daily > 0)
+    .map((item) => ({
+      date: item.date,
+      totalRatings: item.totalRatings,
+      average: safeAverage(item.totalScore, item.totalRatings),
+      dailyRatings: item.modeBreakdown.daily
+    }))
+    .sort((a, b) => {
+      if (b.average === a.average) {
+        return b.totalRatings - a.totalRatings
+      }
+      return b.average - a.average
+    })
+    .slice(0, 5)
+
+  const highestVolumeDates = Array.from(ratingsByDate.values())
+    .sort((a, b) => b.totalRatings - a.totalRatings)
+    .slice(0, 7)
+    .map((item) => ({
+      date: item.date,
+      totalRatings: item.totalRatings,
+      liveRatings: item.modeBreakdown.live,
+      dailyRatings: item.modeBreakdown.daily,
+      average: safeAverage(item.totalScore, item.totalRatings)
+    }))
+
+  const recentRatings = entries
+    .slice()
+    .sort((a, b) => {
+      const aTime = new Date(a.submittedAt || 0).getTime()
+      const bTime = new Date(b.submittedAt || 0).getTime()
+      return bTime - aTime
+    })
+    .slice(0, 12)
+    .map((entry) => ({
+      jokeId: entry.jokeId || 'unknown',
+      mode: entry.mode === 'daily' ? 'daily' : 'live',
+      rating: entry.rating,
+      joke: entry.joke || null,
+      submittedAt: entry.submittedAt,
+      date: entry.date || null
+    }))
+
+  const result = {
+    totals: {
+      overallRatings: totalRatings,
+      overallAverage,
+      uniqueJokes: uniqueJokes.size,
+      firstReviewAt: earliestTimestamp ? new Date(earliestTimestamp).toISOString() : null,
+      latestReviewAt: latestTimestamp ? new Date(latestTimestamp).toISOString() : null,
+      ratingCounts: cloneCounts(overallCounts),
+      live: {
+        totalRatings: modeTotals.live.totalRatings,
+        average: liveAverage,
+        ratingCounts: cloneCounts(modeTotals.live.counts)
+      },
+      daily: {
+        totalRatings: modeTotals.daily.totalRatings,
+        average: dailyAverage,
+        ratingCounts: cloneCounts(modeTotals.daily.counts)
+      }
+    },
+    ratingDistribution: {
+      overall: cloneCounts(overallCounts),
+      live: cloneCounts(modeTotals.live.counts),
+      daily: cloneCounts(modeTotals.daily.counts)
+    },
+    topLiveJokes,
+    topDailyHighlights,
+    highestVolumeDates,
+    recentRatings
+  }
+
+  return result
+}
+
+function validateRating(value) {
+  const rating = Number(value)
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    return null
+  }
+  return rating
+}
+
+export async function handleReadStats({ mode, jokeId, dateKey }) {
+  return readStats({ mode, jokeId, dateKey })
+}
+
+export async function handleWriteReview({ mode, jokeId, dateKey, rating, joke }) {
+  return writeReview({ mode, jokeId, dateKey, rating, joke })
+}
+
+export function resolveDateKey(input) {
+  return getDateKey(input)
+}
+
+export { DEFAULT_COUNTS, getMode, buildDefaultStats, aggregateEntries, normalizeEntry, readEntriesFromDir, readAllRatingEntries, validateRating, getBaseDir }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "eslint-config-next": "13.0.6",
         "next": "13.0.6",
         "openai": "^5.12.0",
+        "prop-types": "^15.8.1",
         "react": "18.2.0",
         "react-audio-player": "^0.17.0",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-config-next": "13.0.6",
     "next": "13.0.6",
     "openai": "^5.12.0",
+    "prop-types": "^15.8.1",
     "react": "18.2.0",
     "react-audio-player": "^0.17.0",
     "react-dom": "18.2.0",

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,341 @@
+import Head from 'next/head'
+import PropTypes from 'prop-types'
+import Header from '../components/Header'
+import styles from '../styles/Dashboard.module.css'
+import { summarizeRatings } from '../lib/ratingsStorage'
+
+const navLinks = [
+  { href: '/', label: 'Live Jokes' },
+  { href: '/speak', label: 'Speak' },
+  { href: '/dashboard', label: 'Dashboard' }
+]
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('en-US').format(Number(value || 0))
+}
+
+function formatAverage(value) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return '—'
+  }
+  return Number(value).toFixed(2)
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '—'
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(date)
+}
+
+function renderRatingCounts(counts = {}) {
+  const entries = [1, 2, 3, 4, 5]
+  return (
+    <dl className={styles.ratingCounts}>
+      {entries.map((score) => (
+        <div key={score} className={styles.ratingCountRow}>
+          <dt>{score}-star</dt>
+          <dd>{formatNumber(counts[score] || 0)}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+function getJokeSnippet(joke) {
+  if (!joke) {
+    return 'No joke text captured for this entry.'
+  }
+  if (joke.length <= 160) {
+    return joke
+  }
+  return `${joke.slice(0, 157)}...`
+}
+
+export default function Dashboard({ summary, error }) {
+  return (
+    <div className={styles.container}>
+      <Head>
+        <title>Joke Insights Dashboard</title>
+      </Head>
+      <Header navLinks={navLinks} />
+      <main className={styles.main}>
+        <section className={styles.hero}>
+          <h1>Joke Insights Dashboard</h1>
+          <p>
+            A quick look at how our daily spotlights and live generated jokes are landing with
+            audiences. Dive into top performers, voting trends, and recent activity.
+          </p>
+        </section>
+        {error && (
+          <section className={styles.errorPanel}>
+            <p>We weren&apos;t able to load the latest stats. Please try again later.</p>
+          </section>
+        )}
+        {!error && summary && (
+          <>
+            <section className={styles.summaryGrid}>
+              <article className={styles.card}>
+                <h2>Total Ratings</h2>
+                <p className={styles.metric}>{formatNumber(summary.totals.overallRatings)}</p>
+                <p className={styles.subtext}>
+                  Across {formatNumber(summary.totals.uniqueJokes)} unique joke experiences.
+                </p>
+              </article>
+              <article className={styles.card}>
+                <h2>Average Score</h2>
+                <p className={styles.metric}>{formatAverage(summary.totals.overallAverage)}</p>
+                <p className={styles.subtext}>
+                  Live jokes average {formatAverage(summary.totals.live.average)} while daily spotlights
+                  average {formatAverage(summary.totals.daily.average)}.
+                </p>
+              </article>
+              <article className={styles.card}>
+                <h2>Live Ratings</h2>
+                <p className={styles.metric}>{formatNumber(summary.totals.live.totalRatings)}</p>
+                <p className={styles.subtext}>Streaming jokes rated in real time.</p>
+              </article>
+              <article className={styles.card}>
+                <h2>Daily Ratings</h2>
+                <p className={styles.metric}>{formatNumber(summary.totals.daily.totalRatings)}</p>
+                <p className={styles.subtext}>Votes on the curated daily feature.</p>
+              </article>
+            </section>
+
+            <section className={styles.section}>
+              <h2>Rating Distribution</h2>
+              <div className={styles.distributionGrid}>
+                <article className={styles.card}>
+                  <h3>Overall</h3>
+                  {renderRatingCounts(summary.ratingDistribution.overall)}
+                </article>
+                <article className={styles.card}>
+                  <h3>Live Jokes</h3>
+                  {renderRatingCounts(summary.ratingDistribution.live)}
+                </article>
+                <article className={styles.card}>
+                  <h3>Daily Spotlights</h3>
+                  {renderRatingCounts(summary.ratingDistribution.daily)}
+                </article>
+              </div>
+            </section>
+
+            <section className={styles.section}>
+              <div className={styles.sectionHeader}>
+                <h2>Top Live Crowd Pleasers</h2>
+                <p>
+                  Sorted by average rating. We include ties by total vote volume so the true crowd
+                  favorites rise to the top.
+                </p>
+              </div>
+              {summary.topLiveJokes.length === 0 ? (
+                <p className={styles.emptyState}>No live joke ratings captured yet.</p>
+              ) : (
+                <div className={styles.tableWrapper}>
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>Joke</th>
+                        <th>Average</th>
+                        <th>Votes</th>
+                        <th>Last Rated</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {summary.topLiveJokes.map((joke) => (
+                        <tr key={joke.jokeId}>
+                          <td>{getJokeSnippet(joke.joke) || joke.jokeId}</td>
+                          <td>{formatAverage(joke.average)}</td>
+                          <td>{formatNumber(joke.totalRatings)}</td>
+                          <td>{formatDate(joke.lastRatedAt)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+
+            <section className={styles.section}>
+              <div className={styles.sectionHeader}>
+                <h2>Daily Spotlight Leaders</h2>
+                <p>
+                  Which daily feature earned the biggest laughs? A mix of strong averages and solid
+                  participation.
+                </p>
+              </div>
+              {summary.topDailyHighlights.length === 0 ? (
+                <p className={styles.emptyState}>Daily jokes haven&apos;t been rated yet.</p>
+              ) : (
+                <div className={styles.tableWrapper}>
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>Date</th>
+                        <th>Average</th>
+                        <th>Total Votes</th>
+                        <th>Daily Votes</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {summary.topDailyHighlights.map((item) => (
+                        <tr key={item.date}>
+                          <td>{formatDate(item.date)}</td>
+                          <td>{formatAverage(item.average)}</td>
+                          <td>{formatNumber(item.totalRatings)}</td>
+                          <td>{formatNumber(item.dailyRatings)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+
+            <section className={styles.section}>
+              <div className={styles.sectionHeader}>
+                <h2>Most Active Dates</h2>
+                <p>The busiest days across both joke modes, with average sentiment for each day.</p>
+              </div>
+              {summary.highestVolumeDates.length === 0 ? (
+                <p className={styles.emptyState}>No voting activity recorded yet.</p>
+              ) : (
+                <div className={styles.tableWrapper}>
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>Date</th>
+                        <th>Total Votes</th>
+                        <th>Live Votes</th>
+                        <th>Daily Votes</th>
+                        <th>Average</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {summary.highestVolumeDates.map((item) => (
+                        <tr key={item.date}>
+                          <td>{formatDate(item.date)}</td>
+                          <td>{formatNumber(item.totalRatings)}</td>
+                          <td>{formatNumber(item.liveRatings)}</td>
+                          <td>{formatNumber(item.dailyRatings)}</td>
+                          <td>{formatAverage(item.average)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+
+            <section className={styles.section}>
+              <div className={styles.sectionHeader}>
+                <h2>Latest Votes</h2>
+                <p>Fresh feedback from the community to keep tabs on how jokes are landing.</p>
+              </div>
+              {summary.recentRatings.length === 0 ? (
+                <p className={styles.emptyState}>No ratings submitted yet.</p>
+              ) : (
+                <ul className={styles.recentList}>
+                  {summary.recentRatings.map((item, index) => (
+                    <li key={`${item.jokeId}-${item.submittedAt}-${index}`} className={styles.recentItem}>
+                      <div className={styles.recentMeta}>
+                        <span className={styles.recentMode}>{item.mode === 'daily' ? 'Daily' : 'Live'}</span>
+                        <span>{formatDate(item.submittedAt || item.date)}</span>
+                        <span className={styles.recentRating}>{item.rating}★</span>
+                      </div>
+                      <p className={styles.recentJoke}>
+                        {item.mode === 'live'
+                          ? getJokeSnippet(item.joke) || `Joke ${item.jokeId}`
+                          : `Daily feature for ${formatDate(item.date || item.submittedAt)}`}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}
+
+Dashboard.propTypes = {
+  summary: PropTypes.shape({
+    totals: PropTypes.shape({
+      overallRatings: PropTypes.number,
+      overallAverage: PropTypes.number,
+      uniqueJokes: PropTypes.number,
+      ratingCounts: PropTypes.object,
+      live: PropTypes.shape({
+        totalRatings: PropTypes.number,
+        average: PropTypes.number
+      }),
+      daily: PropTypes.shape({
+        totalRatings: PropTypes.number,
+        average: PropTypes.number
+      })
+    }),
+    ratingDistribution: PropTypes.shape({
+      overall: PropTypes.object,
+      live: PropTypes.object,
+      daily: PropTypes.object
+    }),
+    topLiveJokes: PropTypes.arrayOf(
+      PropTypes.shape({
+        jokeId: PropTypes.string,
+        joke: PropTypes.string,
+        totalRatings: PropTypes.number,
+        average: PropTypes.number,
+        lastRatedAt: PropTypes.string
+      })
+    ),
+    topDailyHighlights: PropTypes.arrayOf(
+      PropTypes.shape({
+        date: PropTypes.string,
+        totalRatings: PropTypes.number,
+        average: PropTypes.number,
+        dailyRatings: PropTypes.number
+      })
+    ),
+    highestVolumeDates: PropTypes.arrayOf(
+      PropTypes.shape({
+        date: PropTypes.string,
+        totalRatings: PropTypes.number,
+        liveRatings: PropTypes.number,
+        dailyRatings: PropTypes.number,
+        average: PropTypes.number
+      })
+    ),
+    recentRatings: PropTypes.arrayOf(
+      PropTypes.shape({
+        jokeId: PropTypes.string,
+        mode: PropTypes.string,
+        rating: PropTypes.number,
+        joke: PropTypes.string,
+        submittedAt: PropTypes.string,
+        date: PropTypes.string
+      })
+    )
+  }),
+  error: PropTypes.bool
+}
+
+Dashboard.defaultProps = {
+  summary: null,
+  error: false
+}
+
+export async function getServerSideProps() {
+  try {
+    const summary = await summarizeRatings()
+    return { props: { summary } }
+  } catch (err) {
+    console.error('[dashboard] Unable to load summary', err)
+    return { props: { summary: null, error: true } }
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -512,8 +512,9 @@ class OpenAIData extends React.Component {
 
 export default function Home() {
   const navLinks = [
-    { href: '/', label: 'Home' },
-    { href: '/speak', label: 'Speak' }
+    { href: '/', label: 'Live Jokes' },
+    { href: '/speak', label: 'Speak' },
+    { href: '/dashboard', label: 'Dashboard' }
   ];
   return (
     <div className={styles.container}>

--- a/pages/speak.js
+++ b/pages/speak.js
@@ -14,8 +14,9 @@ export default function SpeechHelper() {
   const [voice, setVoice] = useState('coral');
 
   const navLinks = [
-    { href: '/', label: 'Home' },
-    { href: '/speak', label: 'Speak' }
+    { href: '/', label: 'Live Jokes' },
+    { href: '/speak', label: 'Speak' },
+    { href: '/dashboard', label: 'Dashboard' }
   ];
 
   const handleInputChange = (event) => {

--- a/styles/Dashboard.module.css
+++ b/styles/Dashboard.module.css
@@ -1,0 +1,222 @@
+.container {
+  min-height: 100vh;
+  background-color: var(--color-background, #0f172a);
+  color: var(--color-text, #e2e8f0);
+}
+
+.main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(14, 165, 233, 0.15));
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.35);
+}
+
+.hero h1 {
+  margin-bottom: 0.75rem;
+  font-size: 2.5rem;
+  line-height: 1.1;
+}
+
+.hero p {
+  margin: 0;
+  line-height: 1.6;
+  max-width: 720px;
+}
+
+.errorPanel {
+  border-radius: 12px;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  background: rgba(248, 113, 113, 0.15);
+  padding: 1.5rem;
+}
+
+.summaryGrid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.card {
+  background-color: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 14px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 20px rgba(2, 6, 23, 0.35);
+}
+
+.card h2,
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.metric {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.subtext {
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+  line-height: 1.5;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.sectionHeader h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.sectionHeader p {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+  max-width: 720px;
+  line-height: 1.5;
+}
+
+.distributionGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.ratingCounts {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.ratingCountRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.35rem 0.5rem;
+  background-color: rgba(30, 41, 59, 0.7);
+  border-radius: 8px;
+}
+
+.ratingCountRow dt {
+  margin: 0;
+  font-weight: 500;
+}
+
+.ratingCountRow dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.table th {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.table tbody tr:hover {
+  background-color: rgba(30, 41, 59, 0.6);
+}
+
+.emptyState {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 10px;
+  background-color: rgba(30, 41, 59, 0.6);
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.recentList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.recentItem {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 1rem 1.2rem;
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.recentMeta {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.recentMode {
+  background-color: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(56, 189, 248, 0.5);
+  color: rgba(191, 219, 254, 0.95);
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.recentRating {
+  font-weight: 700;
+  font-size: 1.1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.recentJoke {
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (max-width: 768px) {
+  .main {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .hero h1 {
+    font-size: 2.1rem;
+  }
+
+  .table {
+    min-width: 480px;
+  }
+}


### PR DESCRIPTION
## Summary
- extract ratings storage helpers into a reusable module and expose an in-memory aggregation summary
- add a server-rendered /dashboard page with tables, totals, and recent activity for live and daily jokes
- update navigation links and styles so the dashboard is accessible across the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5d22f2f608328a73180e8391567e1