### PR TITLE
Add homepage metrics, featured joke, streak nudge, and fix redundant API call

### DIFF
--- a/__tests__/api/featured-joke.test.js
+++ b/__tests__/api/featured-joke.test.js
@@ -1,0 +1,70 @@
+const mockGetRandomTopJoke = jest.fn()
+
+jest.mock('../../lib/ratingsStorageDynamo', () => ({
+  getRandomTopJoke: mockGetRandomTopJoke
+}))
+
+import { createMocks } from 'node-mocks-http'
+
+const SAMPLE_JOKE = {
+  jokeId: 'joke-abc',
+  opener: 'Why did the scarecrow win an award?',
+  punchline: 'Because he was outstanding in his field!',
+  author: 'Dad',
+  totalRatings: 42,
+  average: 4.8
+}
+
+beforeEach(() => {
+  jest.resetModules()
+  mockGetRandomTopJoke.mockResolvedValue(SAMPLE_JOKE)
+})
+
+describe('GET /api/featured-joke', () => {
+  it('returns the featured joke', async () => {
+    const handler = require('../../pages/api/featured-joke').default
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(200)
+    const data = res._getJSONData()
+    expect(data.opener).toBe(SAMPLE_JOKE.opener)
+    expect(data.punchline).toBe(SAMPLE_JOKE.punchline)
+    expect(data.jokeId).toBe(SAMPLE_JOKE.jokeId)
+    expect(data.totalRatings).toBe(42)
+    expect(data.average).toBe(4.8)
+  })
+
+  it('returns 404 when no top joke is available', async () => {
+    mockGetRandomTopJoke.mockResolvedValue(null)
+    const handler = require('../../pages/api/featured-joke').default
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(404)
+    expect(res._getJSONData()).toHaveProperty('error')
+  })
+
+  it('returns 500 when getRandomTopJoke throws', async () => {
+    mockGetRandomTopJoke.mockRejectedValue(new Error('DynamoDB unavailable'))
+    const handler = require('../../pages/api/featured-joke').default
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(500)
+    expect(res._getJSONData()).toHaveProperty('error')
+  })
+})
+
+describe('non-GET /api/featured-joke', () => {
+  it('returns 405 for POST', async () => {
+    const handler = require('../../pages/api/featured-joke').default
+    const { req, res } = createMocks({ method: 'POST' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(405)
+  })
+
+  it('returns 405 for DELETE', async () => {
+    const handler = require('../../pages/api/featured-joke').default
+    const { req, res } = createMocks({ method: 'DELETE' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(405)
+  })
+})

--- a/__tests__/api/global-stats.test.js
+++ b/__tests__/api/global-stats.test.js
@@ -1,0 +1,51 @@
+const mockReadGlobalStats = jest.fn()
+
+jest.mock('../../lib/ratingsStorageDynamo', () => ({
+  readGlobalStats: mockReadGlobalStats
+}))
+
+import { createMocks } from 'node-mocks-http'
+
+beforeEach(() => {
+  jest.resetModules()
+  mockReadGlobalStats.mockResolvedValue({ totalRatings: 1234, overallAverage: 3.72 })
+})
+
+describe('GET /api/global-stats', () => {
+  it('returns totalRatings and overallAverage', async () => {
+    const handler = require('../../pages/api/global-stats').default
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(200)
+    const data = res._getJSONData()
+    expect(data.totalRatings).toBe(1234)
+    expect(data.overallAverage).toBe(3.72)
+  })
+
+  it('returns 200 with zeros when readGlobalStats throws', async () => {
+    mockReadGlobalStats.mockRejectedValue(new Error('DynamoDB unavailable'))
+    const handler = require('../../pages/api/global-stats').default
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(200)
+    const data = res._getJSONData()
+    expect(data.totalRatings).toBe(0)
+    expect(data.overallAverage).toBe(0)
+  })
+})
+
+describe('non-GET /api/global-stats', () => {
+  it('returns 405 for POST', async () => {
+    const handler = require('../../pages/api/global-stats').default
+    const { req, res } = createMocks({ method: 'POST' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(405)
+  })
+
+  it('returns 405 for DELETE', async () => {
+    const handler = require('../../pages/api/global-stats').default
+    const { req, res } = createMocks({ method: 'DELETE' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(405)
+  })
+})

--- a/__tests__/api/random-joke.test.js
+++ b/__tests__/api/random-joke.test.js
@@ -1,4 +1,6 @@
 const mockSend = jest.fn()
+const mockIsNsfw = jest.fn().mockReturnValue(false)
+const mockFlagJokeAsNsfw = jest.fn().mockResolvedValue(undefined)
 
 jest.mock('../../lib/dynamoClient.js', () => ({
   getDynamoClient: () => ({ send: mockSend }),
@@ -7,6 +9,18 @@ jest.mock('../../lib/dynamoClient.js', () => ({
   QueryCommand: jest.fn().mockImplementation((params) => ({ type: 'Query', params }))
 }))
 
+jest.mock('../../lib/nsfwFilter', () => ({
+  isNsfw: (...args) => mockIsNsfw(...args)
+}))
+
+jest.mock('../../lib/ratingsStorageDynamo', () => {
+  const actual = jest.requireActual('../../lib/ratingsStorageDynamo')
+  return {
+    ...actual,
+    flagJokeAsNsfw: (...args) => mockFlagJokeAsNsfw(...args)
+  }
+})
+
 import handler from '../../pages/api/random-joke'
 import { createMocks } from 'node-mocks-http'
 import { getAllJokes } from '../../lib/jokesData'
@@ -14,8 +28,12 @@ import { getAllJokes } from '../../lib/jokesData'
 describe('GET /api/random-joke', () => {
   beforeEach(() => {
     mockSend.mockReset()
-    // Mock empty custom jokes
+    mockIsNsfw.mockReset()
+    mockFlagJokeAsNsfw.mockReset()
+    // Default: no voted IDs, no flagged IDs, all jokes clean
     mockSend.mockResolvedValue({ Items: [] })
+    mockIsNsfw.mockReturnValue(false)
+    mockFlagJokeAsNsfw.mockResolvedValue(undefined)
   })
 
   it('returns a joke from the dataset', async () => {
@@ -28,5 +46,54 @@ describe('GET /api/random-joke', () => {
     expect(found).toBeDefined()
     expect(data.text).toBe(found.text)
     expect(data.author).toBe(found.author)
+  })
+
+  it('skips an NSFW joke and returns the next clean one', async () => {
+    // Flag only the first call to isNsfw
+    let callCount = 0
+    mockIsNsfw.mockImplementation(() => {
+      callCount++
+      return callCount === 1
+    })
+
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(200)
+    expect(res._getJSONData().id).toBeDefined()
+    expect(mockIsNsfw).toHaveBeenCalledTimes(2)
+  })
+
+  it('calls flagJokeAsNsfw for a detected NSFW joke', async () => {
+    let callCount = 0
+    mockIsNsfw.mockImplementation(() => {
+      callCount++
+      return callCount === 1
+    })
+
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(mockFlagJokeAsNsfw).toHaveBeenCalledTimes(1)
+  })
+
+  it('excludes jokes whose IDs are in the NSFW flag list', async () => {
+    const jokes = getAllJokes()
+    const flaggedId = jokes[0].id
+    mockSend
+      .mockResolvedValueOnce({ Items: [] })                    // voted
+      .mockResolvedValueOnce({ Items: [{ SK: flaggedId }] })  // flagged
+
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(200)
+    expect(res._getJSONData().id).not.toBe(flaggedId)
+  })
+
+  it('returns exhausted when all remaining candidates are NSFW', async () => {
+    mockIsNsfw.mockReturnValue(true)
+
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(200)
+    expect(res._getJSONData().exhausted).toBe(true)
   })
 })

--- a/__tests__/lib/nsfwFilter.test.js
+++ b/__tests__/lib/nsfwFilter.test.js
@@ -69,6 +69,22 @@ describe('isNsfw', () => {
 
   // ── Sexual content ────────────────────────────────────────────────────────
 
+  it('flags "sex"', () => {
+    expect(isNsfw('the joke is about sex')).toBe(true)
+  })
+
+  it('flags "sexy"', () => {
+    expect(isNsfw('that is sexy')).toBe(true)
+  })
+
+  it('flags "sexual"', () => {
+    expect(isNsfw('sexual content')).toBe(true)
+  })
+
+  it('flags "bisexual"', () => {
+    expect(isNsfw('he is bisexual')).toBe(true)
+  })
+
   it('flags "cock" as a standalone word', () => {
     expect(isNsfw('He grabbed his cock')).toBe(true)
   })

--- a/__tests__/lib/nsfwFilter.test.js
+++ b/__tests__/lib/nsfwFilter.test.js
@@ -1,0 +1,149 @@
+import { isNsfw } from '../../lib/nsfwFilter'
+
+describe('isNsfw', () => {
+  // ── Safe inputs ──────────────────────────────────────────────────────────
+
+  it('returns false for a clean dad joke', () => {
+    expect(isNsfw('Why did the scarecrow win an award? Because he was outstanding in his field!')).toBe(false)
+  })
+
+  it('returns false for an empty string', () => {
+    expect(isNsfw('')).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isNsfw(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isNsfw(undefined)).toBe(false)
+  })
+
+  // ── Word-boundary false-positive guards ──────────────────────────────────
+
+  it('does not flag "classic" (contains "ass" as substring)', () => {
+    expect(isNsfw('That was a classic joke')).toBe(false)
+  })
+
+  it('does not flag "grass"', () => {
+    expect(isNsfw('The grass is always greener')).toBe(false)
+  })
+
+  it('does not flag "cockroach"', () => {
+    expect(isNsfw('There was a cockroach in the kitchen')).toBe(false)
+  })
+
+  it('does not flag "cocktail"', () => {
+    expect(isNsfw('He ordered a cocktail')).toBe(false)
+  })
+
+  it('does not flag "analysis"', () => {
+    expect(isNsfw('After careful analysis, the joke was terrible')).toBe(false)
+  })
+
+  it('does not flag "scum" (contains "cum" as substring)', () => {
+    expect(isNsfw('The scum of the earth')).toBe(false)
+  })
+
+  // ── Profanity detection ──────────────────────────────────────────────────
+
+  it('flags text containing "fuck"', () => {
+    expect(isNsfw('what the fuck')).toBe(true)
+  })
+
+  it('flags "fucking" (prefix match)', () => {
+    expect(isNsfw('That was fucking terrible')).toBe(true)
+  })
+
+  it('flags "shit"', () => {
+    expect(isNsfw('That joke is shit')).toBe(true)
+  })
+
+  it('flags "ass" as a standalone word', () => {
+    expect(isNsfw('Kick his ass')).toBe(true)
+  })
+
+  it('flags "bitch"', () => {
+    expect(isNsfw('You son of a bitch')).toBe(true)
+  })
+
+  // ── Sexual content ────────────────────────────────────────────────────────
+
+  it('flags "cock" as a standalone word', () => {
+    expect(isNsfw('He grabbed his cock')).toBe(true)
+  })
+
+  it('flags "dick" as a standalone word', () => {
+    expect(isNsfw('Don\'t be a dick')).toBe(true)
+  })
+
+  it('flags "pussy"', () => {
+    expect(isNsfw('Don\'t be such a pussy')).toBe(true)
+  })
+
+  it('flags "cum" as a standalone word', () => {
+    expect(isNsfw('He started to cum')).toBe(true)
+  })
+
+  it('flags "penis"', () => {
+    expect(isNsfw('He exposed his penis')).toBe(true)
+  })
+
+  it('flags "vagina"', () => {
+    expect(isNsfw('vagina joke here')).toBe(true)
+  })
+
+  it('flags "boobs"', () => {
+    expect(isNsfw('Nice boobs')).toBe(true)
+  })
+
+  it('flags "tits"', () => {
+    expect(isNsfw('Check out her tits')).toBe(true)
+  })
+
+  it('flags "porn"', () => {
+    expect(isNsfw('He was watching porn')).toBe(true)
+  })
+
+  it('flags "masturbating" (prefix match on masturbat)', () => {
+    expect(isNsfw('caught him masturbating')).toBe(true)
+  })
+
+  it('flags "blowjob"', () => {
+    expect(isNsfw('she gave him a blowjob')).toBe(true)
+  })
+
+  // ── Slurs ────────────────────────────────────────────────────────────────
+
+  it('flags the n-word', () => {
+    expect(isNsfw('used the n-word nigger here')).toBe(true)
+  })
+
+  it('flags "faggot"', () => {
+    expect(isNsfw('called him a faggot')).toBe(true)
+  })
+
+  // ── Abuse ────────────────────────────────────────────────────────────────
+
+  it('flags "rape"', () => {
+    expect(isNsfw('joke about rape')).toBe(true)
+  })
+
+  it('flags "molested"', () => {
+    expect(isNsfw('he molested someone')).toBe(true)
+  })
+
+  it('flags "pedophile" (prefix match on pedophil)', () => {
+    expect(isNsfw('he is a pedophile')).toBe(true)
+  })
+
+  // ── Case insensitivity ───────────────────────────────────────────────────
+
+  it('flags uppercase variants', () => {
+    expect(isNsfw('WHAT THE FUCK')).toBe(true)
+  })
+
+  it('flags mixed-case variants', () => {
+    expect(isNsfw('What The Fuck')).toBe(true)
+  })
+})

--- a/__tests__/lib/ratingsStorageDynamo.test.js
+++ b/__tests__/lib/ratingsStorageDynamo.test.js
@@ -1,0 +1,140 @@
+const mockSend = jest.fn()
+
+jest.mock('../../lib/dynamoClient.js', () => ({
+  getDynamoClient: () => ({ send: mockSend }),
+  RATINGS_TABLE: 'test-ratings-table',
+  STATS_TABLE: 'test-stats-table',
+  GetCommand: jest.fn().mockImplementation((params) => ({ type: 'Get', params })),
+  QueryCommand: jest.fn().mockImplementation((params) => ({ type: 'Query', params })),
+  PutCommand: jest.fn().mockImplementation((params) => ({ type: 'Put', params })),
+}))
+
+import { readGlobalStats, getRandomTopJoke } from '../../lib/ratingsStorageDynamo.js'
+
+beforeEach(() => {
+  mockSend.mockReset()
+})
+
+// ─── readGlobalStats ──────────────────────────────────────────────────────────
+
+describe('readGlobalStats', () => {
+  it('returns totalRatings and overallAverage from the GLOBAL AGGREGATE item', async () => {
+    mockSend.mockResolvedValue({
+      Item: { totalRatings: 250, totalScore: 875, count1: 10, count2: 30, count3: 60, count4: 90, count5: 60 }
+    })
+    const result = await readGlobalStats()
+    expect(result.totalRatings).toBe(250)
+    expect(result.overallAverage).toBe(3.5)
+  })
+
+  it('returns zeros when the GLOBAL item does not exist yet', async () => {
+    mockSend.mockResolvedValue({})
+    const result = await readGlobalStats()
+    expect(result.totalRatings).toBe(0)
+    expect(result.overallAverage).toBe(0)
+  })
+
+  it('returns zero average when totalScore is missing', async () => {
+    mockSend.mockResolvedValue({ Item: { totalRatings: 5 } })
+    const result = await readGlobalStats()
+    expect(result.overallAverage).toBe(0)
+  })
+
+  it('rounds overallAverage to two decimal places', async () => {
+    mockSend.mockResolvedValue({ Item: { totalRatings: 3, totalScore: 10 } })
+    const result = await readGlobalStats()
+    expect(result.overallAverage).toBe(3.33)
+  })
+})
+
+// ─── getRandomTopJoke ─────────────────────────────────────────────────────────
+
+describe('getRandomTopJoke', () => {
+  const makeItem = (overrides = {}) => ({
+    PK: 'STATS#joke-abc',
+    jokeText: 'Why did the scarecrow win an award? || Because he was outstanding in his field!',
+    author: 'Dad',
+    totalRatings: 5,
+    GSI1SK: 4.8,
+    ...overrides
+  })
+
+  it('returns a joke with opener and punchline split on " || "', async () => {
+    mockSend.mockResolvedValue({ Items: [makeItem()], Count: 1 })
+    const result = await getRandomTopJoke()
+    expect(result).not.toBeNull()
+    expect(result.opener).toBe('Why did the scarecrow win an award?')
+    expect(result.punchline).toBe('Because he was outstanding in his field!')
+    expect(result.jokeId).toBe('joke-abc')
+    expect(result.author).toBe('Dad')
+    expect(result.totalRatings).toBe(5)
+    expect(result.average).toBe(4.8)
+  })
+
+  it('returns null when no items are returned', async () => {
+    mockSend.mockResolvedValue({ Items: [], Count: 0 })
+    const result = await getRandomTopJoke()
+    expect(result).toBeNull()
+  })
+
+  it('returns null when all items are filtered out due to low vote count', async () => {
+    mockSend.mockResolvedValue({
+      Items: [makeItem({ totalRatings: 1 }), makeItem({ totalRatings: 2 })],
+      Count: 2
+    })
+    const result = await getRandomTopJoke()
+    expect(result).toBeNull()
+  })
+
+  it('returns null when all items have no jokeText', async () => {
+    mockSend.mockResolvedValue({
+      Items: [makeItem({ jokeText: null }), makeItem({ jokeText: '' })],
+      Count: 2
+    })
+    const result = await getRandomTopJoke()
+    expect(result).toBeNull()
+  })
+
+  it('handles a joke with no punchline separator', async () => {
+    mockSend.mockResolvedValue({
+      Items: [makeItem({ jokeText: 'Just a single line joke' })],
+      Count: 1
+    })
+    const result = await getRandomTopJoke()
+    expect(result.opener).toBe('Just a single line joke')
+    expect(result.punchline).toBe('')
+  })
+
+  it('sets author to null when missing from item', async () => {
+    mockSend.mockResolvedValue({
+      Items: [makeItem({ author: undefined })],
+      Count: 1
+    })
+    const result = await getRandomTopJoke()
+    expect(result.author).toBeNull()
+  })
+
+  it('strips the STATS# prefix from jokeId', async () => {
+    mockSend.mockResolvedValue({
+      Items: [makeItem({ PK: 'STATS#custom-joke-999' })],
+      Count: 1
+    })
+    const result = await getRandomTopJoke()
+    expect(result.jokeId).toBe('custom-joke-999')
+  })
+
+  it('returns one of the eligible candidates at random', async () => {
+    const items = [
+      makeItem({ PK: 'STATS#joke-1', jokeText: 'Q1 || A1' }),
+      makeItem({ PK: 'STATS#joke-2', jokeText: 'Q2 || A2' }),
+      makeItem({ PK: 'STATS#joke-3', jokeText: 'Q3 || A3' }),
+    ]
+    mockSend.mockResolvedValue({ Items: items, Count: 3 })
+    const ids = new Set()
+    for (let i = 0; i < 30; i++) {
+      const result = await getRandomTopJoke()
+      ids.add(result.jokeId)
+    }
+    expect(ids.size).toBeGreaterThan(1)
+  })
+})

--- a/__tests__/lib/ratingsStorageDynamo.test.js
+++ b/__tests__/lib/ratingsStorageDynamo.test.js
@@ -10,6 +10,7 @@ jest.mock('../../lib/dynamoClient.js', () => ({
 }))
 
 import { readGlobalStats, getRandomTopJoke } from '../../lib/ratingsStorageDynamo.js'
+import { QueryCommand } from '../../lib/dynamoClient.js'
 
 beforeEach(() => {
   mockSend.mockReset()
@@ -121,6 +122,16 @@ describe('getRandomTopJoke', () => {
     })
     const result = await getRandomTopJoke()
     expect(result.jokeId).toBe('custom-joke-999')
+  })
+
+  it('queries DynamoDB with GSI1SK >= 4.0 so low-rated jokes are excluded at the source', async () => {
+    mockSend.mockResolvedValue({ Items: [makeItem()], Count: 1 })
+    await getRandomTopJoke()
+    // The argument passed to mockSend is the result of `new QueryCommand(params)`,
+    // which our mock wraps as { type: 'Query', params }.
+    const sentArg = mockSend.mock.calls[0][0]
+    expect(sentArg.params.KeyConditionExpression).toContain('GSI1SK >= :minAvg')
+    expect(sentArg.params.ExpressionAttributeValues[':minAvg']).toBe(4.0)
   })
 
   it('returns one of the eligible candidates at random', async () => {

--- a/lib/nsfwFilter.js
+++ b/lib/nsfwFilter.js
@@ -16,6 +16,8 @@ const NSFW_REGEX = new RegExp(
     '\\bass\\b',
     '\\barse\\b',
     // Sexual
+    '\\bsex',
+    'bisexual',
     '\\bcock\\b',
     '\\bdick\\b',
     '\\bpussy\\b',

--- a/lib/nsfwFilter.js
+++ b/lib/nsfwFilter.js
@@ -1,0 +1,57 @@
+// lib/nsfwFilter.js
+// Word-boundary-aware NSFW detection for joke content.
+// Flagged jokes are stored in DynamoDB for admin review — users never see them.
+
+// Most terms use \b on both sides to avoid false positives inside longer words
+// (e.g. /\bass\b/ won't fire on "classic" or "grass").
+// Prefix-only patterns (masturbat, pedophil, blowjob, handjob) catch common
+// conjugations without needing an exhaustive list of variants.
+const NSFW_REGEX = new RegExp(
+  [
+    // Profanity
+    '\\bfuck',
+    '\\bshit\\b',
+    '\\bcunt\\b',
+    '\\bbitch\\b',
+    '\\bass\\b',
+    '\\barse\\b',
+    // Sexual
+    '\\bcock\\b',
+    '\\bdick\\b',
+    '\\bpussy\\b',
+    '\\bcum\\b',
+    '\\bjizz\\b',
+    '\\bpenis\\b',
+    '\\bvagina\\b',
+    '\\bdildo\\b',
+    '\\bboob',
+    '\\btits?\\b',
+    '\\bporn\\b',
+    '\\bhorny\\b',
+    '\\borgasm\\b',
+    '\\bboner\\b',
+    '\\banal\\b',
+    'masturbat',
+    'blowjob',
+    'handjob',
+    // Slurs
+    '\\bnigger\\b',
+    '\\bnigga\\b',
+    '\\bfaggot\\b',
+    '\\bfag\\b',
+    // Abuse
+    '\\brape\\b',
+    '\\bmolest',
+    'pedophil',
+  ].join('|'),
+  'i'
+)
+
+/**
+ * Returns true if the given text contains NSFW content.
+ * Designed for speed — synchronous, no external calls.
+ */
+export function isNsfw(text) {
+  if (!text || typeof text !== 'string') return false
+  return NSFW_REGEX.test(text)
+}

--- a/lib/ratingsStorageDynamo.js
+++ b/lib/ratingsStorageDynamo.js
@@ -192,13 +192,23 @@ function parseGlobalItem(item) {
   };
 }
 
-// Queries the TOP_PERFORMERS GSI and maps items to a common shape
-async function readTopPerformers(client, limit = 8) {
+// Queries the TOP_PERFORMERS GSI and maps items to a common shape.
+// NOTE: every stats item lives in this GSI regardless of average — "top" only
+// refers to the sort order (GSI1SK = average, descending).  Pass minAverage to
+// push a floor condition into the KeyConditionExpression so DynamoDB filters at
+// query time instead of returning low-rated jokes and discarding them client-side.
+async function readTopPerformers(client, limit = 8, minAverage = null) {
+  const hasMin = minAverage !== null && minAverage !== undefined;
   const result = await client.send(new QueryCommand({
     TableName: STATS_TABLE,
     IndexName: 'GSI1',
-    KeyConditionExpression: 'GSI1PK = :pk',
-    ExpressionAttributeValues: { ':pk': 'TOP_PERFORMERS' },
+    KeyConditionExpression: hasMin
+      ? 'GSI1PK = :pk AND GSI1SK >= :minAvg'
+      : 'GSI1PK = :pk',
+    ExpressionAttributeValues: {
+      ':pk': 'TOP_PERFORMERS',
+      ...(hasMin ? { ':minAvg': minAverage } : {})
+    },
     ScanIndexForward: false,
     Limit: limit
   }));
@@ -225,10 +235,11 @@ export async function readGlobalStats() {
   return { totalRatings, overallAverage };
 }
 
-// Returns one random joke from the top-rated pool — used for the featured joke
+// Returns one random joke from the top-rated pool — used for the featured joke.
+// Only considers jokes with an average rating >= 4.0.
 export async function getRandomTopJoke() {
   const client = getDynamoClient();
-  const { items } = await readTopPerformers(client, 50);
+  const { items } = await readTopPerformers(client, 50, 4.0);
   const candidates = items.filter(p => p.joke);
   if (candidates.length === 0) return null;
   const pick = candidates[Math.floor(Math.random() * candidates.length)];

--- a/lib/ratingsStorageDynamo.js
+++ b/lib/ratingsStorageDynamo.js
@@ -188,7 +188,7 @@ export async function readGlobalStats() {
 // Returns one random joke from the top-rated pool — used for the featured joke
 export async function getRandomTopJoke() {
   const client = getDynamoClient();
-  const { items } = await readTopPerformers(client, 10);
+  const { items } = await readTopPerformers(client, 50);
   const candidates = items.filter(p => p.joke);
   if (candidates.length === 0) return null;
   const pick = candidates[Math.floor(Math.random() * candidates.length)];

--- a/lib/ratingsStorageDynamo.js
+++ b/lib/ratingsStorageDynamo.js
@@ -124,6 +124,46 @@ export async function readStats({ jokeId }) {
   };
 }
 
+// ─── NSFW flagging ───────────────────────────────────────────────────────────
+
+// Returns the set of joke IDs that have been flagged as NSFW for admin review.
+// Stored as RATINGS_TABLE items with PK='NSFW_FLAGS' so a single Query loads all.
+export async function getFlaggedJokeIds() {
+  try {
+    const client = getDynamoClient();
+    const result = await client.send(new QueryCommand({
+      TableName: RATINGS_TABLE,
+      KeyConditionExpression: 'PK = :pk',
+      ExpressionAttributeValues: { ':pk': 'NSFW_FLAGS' },
+      ProjectionExpression: 'SK'
+    }));
+    return new Set((result.Items || []).map(item => item.SK));
+  } catch (error) {
+    console.error('[ratings] Failed to load NSFW flag list, failing open', { error });
+    return new Set();
+  }
+}
+
+// Records a joke as NSFW so it can be reviewed and excluded from future serves.
+// Idempotent — safe to call multiple times for the same jokeId.
+export async function flagJokeAsNsfw(jokeId, jokeText, author) {
+  try {
+    const client = getDynamoClient();
+    await client.send(new PutCommand({
+      TableName: RATINGS_TABLE,
+      Item: {
+        PK: 'NSFW_FLAGS',
+        SK: jokeId,
+        jokeText: jokeText || null,
+        author: author || null,
+        flaggedAt: new Date().toISOString()
+      }
+    }));
+  } catch (error) {
+    console.error('[ratings] Failed to flag joke as NSFW', { jokeId, error });
+  }
+}
+
 // ─── Shared internal helpers ──────────────────────────────────────────────────
 
 // Fetches the raw GLOBAL AGGREGATE item from STATS_TABLE

--- a/lib/ratingsStorageDynamo.js
+++ b/lib/ratingsStorageDynamo.js
@@ -164,6 +164,49 @@ export async function getWeeklyTopJokes() {
     .slice(0, 20)
 }
 
+// O(1) read for global totals — used by homepage live counter
+export async function readGlobalStats() {
+  const client = getDynamoClient();
+  const result = await client.send(new GetCommand({
+    TableName: STATS_TABLE,
+    Key: { PK: 'GLOBAL', SK: 'AGGREGATE' }
+  }));
+  const item = result.Item || {};
+  return {
+    totalRatings: item.totalRatings || 0,
+    overallAverage: item.totalScore && item.totalRatings
+      ? Number((item.totalScore / item.totalRatings).toFixed(2))
+      : 0
+  };
+}
+
+// Returns one random joke from the top-rated pool — used for the featured joke
+export async function getRandomTopJoke() {
+  const client = getDynamoClient();
+  const result = await client.send(new QueryCommand({
+    TableName: STATS_TABLE,
+    IndexName: 'GSI1',
+    KeyConditionExpression: 'GSI1PK = :pk',
+    ExpressionAttributeValues: { ':pk': 'TOP_PERFORMERS' },
+    ScanIndexForward: false,
+    Limit: 10
+  }));
+  const candidates = (result.Items || []).filter(
+    item => (item.totalRatings || 0) >= 3 && item.jokeText
+  );
+  if (candidates.length === 0) return null;
+  const pick = candidates[Math.floor(Math.random() * candidates.length)];
+  const parts = (pick.jokeText || '').split(' || ');
+  return {
+    jokeId: pick.PK.replace('STATS#', ''),
+    opener: parts[0]?.trim() || '',
+    punchline: parts[1]?.trim() || '',
+    author: pick.author || null,
+    totalRatings: pick.totalRatings || 0,
+    average: pick.GSI1SK || 0
+  };
+}
+
 // O(1) read for dashboard - pre-computed global stats
 export async function getDashboardStats() {
   const client = getDynamoClient();

--- a/lib/ratingsStorageDynamo.js
+++ b/lib/ratingsStorageDynamo.js
@@ -124,6 +124,85 @@ export async function readStats({ jokeId }) {
   };
 }
 
+// ─── Shared internal helpers ──────────────────────────────────────────────────
+
+// Fetches the raw GLOBAL AGGREGATE item from STATS_TABLE
+async function readGlobalItem(client) {
+  const result = await client.send(new GetCommand({
+    TableName: STATS_TABLE,
+    Key: { PK: 'GLOBAL', SK: 'AGGREGATE' }
+  }));
+  return result.Item || {};
+}
+
+// Parses a GLOBAL AGGREGATE item into structured stats
+function parseGlobalItem(item) {
+  return {
+    totalRatings: item.totalRatings || 0,
+    overallAverage: item.totalScore && item.totalRatings
+      ? Number((item.totalScore / item.totalRatings).toFixed(2))
+      : 0,
+    ratingCounts: {
+      1: item.count1 || 0,
+      2: item.count2 || 0,
+      3: item.count3 || 0,
+      4: item.count4 || 0,
+      5: item.count5 || 0
+    }
+  };
+}
+
+// Queries the TOP_PERFORMERS GSI and maps items to a common shape
+async function readTopPerformers(client, limit = 8) {
+  const result = await client.send(new QueryCommand({
+    TableName: STATS_TABLE,
+    IndexName: 'GSI1',
+    KeyConditionExpression: 'GSI1PK = :pk',
+    ExpressionAttributeValues: { ':pk': 'TOP_PERFORMERS' },
+    ScanIndexForward: false,
+    Limit: limit
+  }));
+  const items = (result.Items || [])
+    .filter(item => (item.totalRatings || 0) >= 3)
+    .map(item => ({
+      jokeId: item.PK.replace('STATS#', ''),
+      joke: item.jokeText,
+      author: item.author,
+      totalRatings: item.totalRatings || 0,
+      average: item.GSI1SK || 0,
+      lastRatedAt: item.lastRatedAt
+    }));
+  return { items, count: result.Count || 0 };
+}
+
+// ─── Public exports ───────────────────────────────────────────────────────────
+
+// O(1) read for global totals — used by homepage live counter
+export async function readGlobalStats() {
+  const client = getDynamoClient();
+  const item = await readGlobalItem(client);
+  const { totalRatings, overallAverage } = parseGlobalItem(item);
+  return { totalRatings, overallAverage };
+}
+
+// Returns one random joke from the top-rated pool — used for the featured joke
+export async function getRandomTopJoke() {
+  const client = getDynamoClient();
+  const { items } = await readTopPerformers(client, 10);
+  const candidates = items.filter(p => p.joke);
+  if (candidates.length === 0) return null;
+  const pick = candidates[Math.floor(Math.random() * candidates.length)];
+  const parts = (pick.joke || '').split(' || ');
+  return {
+    jokeId: pick.jokeId,
+    opener: parts[0]?.trim() || '',
+    punchline: parts[1]?.trim() || '',
+    author: pick.author || null,
+    totalRatings: pick.totalRatings,
+    average: pick.average
+  };
+}
+
 // Top jokes from the past 7 days — aggregates raw rating records from GSI1
 export async function getWeeklyTopJokes() {
   const client = getDynamoClient()
@@ -164,60 +243,13 @@ export async function getWeeklyTopJokes() {
     .slice(0, 20)
 }
 
-// O(1) read for global totals — used by homepage live counter
-export async function readGlobalStats() {
-  const client = getDynamoClient();
-  const result = await client.send(new GetCommand({
-    TableName: STATS_TABLE,
-    Key: { PK: 'GLOBAL', SK: 'AGGREGATE' }
-  }));
-  const item = result.Item || {};
-  return {
-    totalRatings: item.totalRatings || 0,
-    overallAverage: item.totalScore && item.totalRatings
-      ? Number((item.totalScore / item.totalRatings).toFixed(2))
-      : 0
-  };
-}
-
-// Returns one random joke from the top-rated pool — used for the featured joke
-export async function getRandomTopJoke() {
-  const client = getDynamoClient();
-  const result = await client.send(new QueryCommand({
-    TableName: STATS_TABLE,
-    IndexName: 'GSI1',
-    KeyConditionExpression: 'GSI1PK = :pk',
-    ExpressionAttributeValues: { ':pk': 'TOP_PERFORMERS' },
-    ScanIndexForward: false,
-    Limit: 10
-  }));
-  const candidates = (result.Items || []).filter(
-    item => (item.totalRatings || 0) >= 3 && item.jokeText
-  );
-  if (candidates.length === 0) return null;
-  const pick = candidates[Math.floor(Math.random() * candidates.length)];
-  const parts = (pick.jokeText || '').split(' || ');
-  return {
-    jokeId: pick.PK.replace('STATS#', ''),
-    opener: parts[0]?.trim() || '',
-    punchline: parts[1]?.trim() || '',
-    author: pick.author || null,
-    totalRatings: pick.totalRatings || 0,
-    average: pick.GSI1SK || 0
-  };
-}
-
 // O(1) read for dashboard - pre-computed global stats
 export async function getDashboardStats() {
   const client = getDynamoClient();
 
-  // Parallel queries for global stats, author stats, and top performers
-  const [globalResult, authorsResult, topPerformersResult, recentResult] = await Promise.all([
-    // Global aggregate
-    client.send(new GetCommand({
-      TableName: STATS_TABLE,
-      Key: { PK: 'GLOBAL', SK: 'AGGREGATE' }
-    })),
+  // All 4 queries run in parallel
+  const [globalItem, authorsResult, topResult, recentResult] = await Promise.all([
+    readGlobalItem(client),
 
     // Author stats (query all AUTHOR# sort keys)
     client.send(new QueryCommand({
@@ -229,15 +261,7 @@ export async function getDashboardStats() {
       }
     })),
 
-    // Top performers (from GSI, sorted by average rating)
-    client.send(new QueryCommand({
-      TableName: STATS_TABLE,
-      IndexName: 'GSI1',
-      KeyConditionExpression: 'GSI1PK = :pk',
-      ExpressionAttributeValues: { ':pk': 'TOP_PERFORMERS' },
-      ScanIndexForward: false,  // Descending by average
-      Limit: 8
-    })),
+    readTopPerformers(client, 8),
 
     // Recent ratings (from GSI on JokeRatings table)
     client.send(new QueryCommand({
@@ -250,7 +274,10 @@ export async function getDashboardStats() {
     }))
   ]);
 
-  const global = globalResult.Item || {};
+  const { totalRatings: overallRatings, overallAverage, ratingCounts } = parseGlobalItem(globalItem);
+  const topPerformers = topResult.items;
+  const uniqueJokes = topResult.count;
+
   const authors = (authorsResult.Items || []).map(item => ({
     author: item.author || item.SK.replace('AUTHOR#', ''),
     totalRatings: item.totalRatings || 0,
@@ -262,17 +289,6 @@ export async function getDashboardStats() {
       4: item.count4 || 0, 5: item.count5 || 0
     }
   })).sort((a, b) => b.totalRatings - a.totalRatings);
-
-  const topPerformers = (topPerformersResult.Items || [])
-    .filter(item => (item.totalRatings || 0) >= 3)
-    .map(item => ({
-      jokeId: item.PK.replace('STATS#', ''),
-      joke: item.jokeText,
-      author: item.author,
-      totalRatings: item.totalRatings || 0,
-      average: item.GSI1SK || 0,
-      lastRatedAt: item.lastRatedAt
-    }));
 
   const recentRatings = (recentResult.Items || []).map(item => ({
     jokeId: item.PK.replace('JOKE#', ''),
@@ -286,22 +302,14 @@ export async function getDashboardStats() {
 
   return {
     totals: {
-      overallRatings: global.totalRatings || 0,
-      overallAverage: global.totalScore && global.totalRatings
-        ? Number((global.totalScore / global.totalRatings).toFixed(2))
-        : 0,
-      uniqueJokes: topPerformersResult.Count || 0,
-      ratingCounts: {
-        1: global.count1 || 0, 2: global.count2 || 0, 3: global.count3 || 0,
-        4: global.count4 || 0, 5: global.count5 || 0
-      },
+      overallRatings,
+      overallAverage,
+      uniqueJokes,
+      ratingCounts,
       byAuthor: authors.map(({ ratingCounts, ...rest }) => rest)
     },
     ratingDistribution: {
-      overall: {
-        1: global.count1 || 0, 2: global.count2 || 0, 3: global.count3 || 0,
-        4: global.count4 || 0, 5: global.count5 || 0
-      },
+      overall: ratingCounts,
       byAuthor: authors.reduce((acc, a) => ({ ...acc, [a.author]: a.ratingCounts }), {})
     },
     topPerformers,

--- a/pages/api/featured-joke.js
+++ b/pages/api/featured-joke.js
@@ -1,0 +1,18 @@
+import { getRandomTopJoke } from '../../lib/ratingsStorageDynamo.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  try {
+    const joke = await getRandomTopJoke();
+    if (!joke) {
+      return res.status(404).json({ error: 'No featured joke available' });
+    }
+    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=600');
+    return res.status(200).json(joke);
+  } catch (error) {
+    console.error('[featured-joke]', error);
+    return res.status(500).json({ error: 'Unable to load featured joke' });
+  }
+}

--- a/pages/api/featured-joke.js
+++ b/pages/api/featured-joke.js
@@ -9,7 +9,7 @@ export default async function handler(req, res) {
     if (!joke) {
       return res.status(404).json({ error: 'No featured joke available' });
     }
-    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=600');
+    res.setHeader('Cache-Control', 'no-store');
     return res.status(200).json(joke);
   } catch (error) {
     console.error('[featured-joke]', error);

--- a/pages/api/global-stats.js
+++ b/pages/api/global-stats.js
@@ -1,0 +1,15 @@
+import { readGlobalStats } from '../../lib/ratingsStorageDynamo.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  try {
+    const stats = await readGlobalStats();
+    res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate=60');
+    return res.status(200).json(stats);
+  } catch (error) {
+    console.error('[global-stats]', error);
+    return res.status(200).json({ totalRatings: 0, overallAverage: 0 });
+  }
+}

--- a/pages/api/random-joke.js
+++ b/pages/api/random-joke.js
@@ -1,5 +1,6 @@
 import { getAllJokesAsync } from '../../lib/jokesData'
-import { getVotedJokeIds } from '../../lib/ratingsStorageDynamo'
+import { getVotedJokeIds, getFlaggedJokeIds, flagJokeAsNsfw } from '../../lib/ratingsStorageDynamo'
+import { isNsfw } from '../../lib/nsfwFilter'
 
 const EXHAUSTED_MESSAGE =
   "You've rated every joke in our collection! I'd tell you another one, but I'm afraid I'm all out of material... get it? Because you've gone through all our material? Anyway, thanks for your tremendous contribution to dad joke science!"
@@ -35,20 +36,39 @@ function getIp(req) {
 export default async function handler(req, res) {
   try {
     const ip = getIp(req)
-    const [allJokes, votedIds] = await Promise.all([
+    const [allJokes, votedIds, flaggedIds] = await Promise.all([
       getAllJokesAsync(),
-      getVotedJokeIds(ip)
+      getVotedJokeIds(ip),
+      getFlaggedJokeIds()
     ])
 
-    const available = votedIds.size > 0
-      ? allJokes.filter((j) => !votedIds.has(j.id))
-      : allJokes
+    const excluded = new Set([...votedIds, ...flaggedIds])
+    let candidates = excluded.size > 0
+      ? allJokes.filter((j) => !excluded.has(j.id))
+      : allJokes.slice()
 
-    if (available.length === 0) {
+    if (candidates.length === 0) {
       return res.status(200).json({ exhausted: true, message: EXHAUSTED_MESSAGE })
     }
 
-    const joke = pickFairJoke(available)
+    // Pick a joke, silently skipping any that contain NSFW content.
+    // Newly detected NSFW jokes are flagged in the DB for admin review.
+    let joke = null
+    while (candidates.length > 0) {
+      const pick = pickFairJoke(candidates)
+      if (isNsfw(pick.text)) {
+        flagJokeAsNsfw(pick.id, pick.text, pick.author).catch(() => {})
+        candidates = candidates.filter((c) => c.id !== pick.id)
+        continue
+      }
+      joke = pick
+      break
+    }
+
+    if (!joke) {
+      return res.status(200).json({ exhausted: true, message: EXHAUSTED_MESSAGE })
+    }
+
     res.status(200).json({
       id: joke.id,
       opener: joke.opener,

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,6 +26,14 @@ function normalizeStats(stats = {}) {
   }
 }
 
+function nextStreakMilestone(count) {
+  const milestones = [5, 10, 25, 50, 100];
+  for (const m of milestones) {
+    if (count < m) return { milestone: m, remaining: m - count };
+  }
+  return null;
+}
+
 function resolveDisplayAuthor(author, metadata) {
   const normalizedAuthor = typeof author === 'string' ? author.trim() : ''
   const nickname = resolveNicknameFromMetadata(metadata)
@@ -74,12 +82,14 @@ class OpenAIData extends React.Component {
       submitMessage: '',
       streakCount: 0,
       jokesExhausted: false,
-      exhaustedMessage: null
+      exhaustedMessage: null,
+      globalVotes: null
     };
   }
 
   componentDidMount() {
     this.fetchJoke();
+    this.fetchGlobalStats();
     try {
       const stored = sessionStorage.getItem('jokeStreak');
       if (stored) {
@@ -88,6 +98,19 @@ class OpenAIData extends React.Component {
       }
     } catch {
       // sessionStorage unavailable or invalid JSON — ignore
+    }
+  }
+
+  fetchGlobalStats = async () => {
+    try {
+      const response = await fetch('/api/global-stats');
+      if (!response.ok) return;
+      const data = await response.json();
+      if (data.totalRatings > 0) {
+        this.setState({ globalVotes: data.totalRatings });
+      }
+    } catch {
+      // Non-critical — ignore
     }
   }
 
@@ -121,23 +144,18 @@ class OpenAIData extends React.Component {
     if (jokeId === currentJokeId) {
       return;
     }
-    this.setState(
-      {
-        currentJokeId: jokeId,
-        currentJokeText: jokeText,
-        currentJokeSpeechText: speechText || jokeText,
-        ratingStats: { ...defaultRatingStats },
-        userRating: null,
-        hoveredRating: null,
-        isSubmittingRating: false,
-        ratingError: null,
-        hasSubmittedRating: false,
-        loadedJokeId: loadedJokeId || null
-      },
-      () => {
-        this.fetchRatingStats(jokeId);
-      }
-    );
+    this.setState({
+      currentJokeId: jokeId,
+      currentJokeText: jokeText,
+      currentJokeSpeechText: speechText || jokeText,
+      ratingStats: { ...defaultRatingStats },
+      userRating: null,
+      hoveredRating: null,
+      isSubmittingRating: false,
+      ratingError: null,
+      hasSubmittedRating: false,
+      loadedJokeId: loadedJokeId || null
+    });
   }
   createJokeId = (text) => {
     let hash = 0;
@@ -146,20 +164,6 @@ class OpenAIData extends React.Component {
       hash |= 0;
     }
     return `joke-${Math.abs(hash)}`;
-  }
-
-  fetchRatingStats = async (jokeId) => {
-    try {
-      const params = new URLSearchParams({ jokeId })
-      const response = await fetch(`/api/ratings?${params.toString()}`);
-      if (!response.ok) {
-        throw new Error('Unable to load ratings');
-      }
-      const data = await response.json();
-      this.setState({ ratingStats: normalizeStats(data), ratingError: null });
-    } catch (error) {
-      this.setState({ ratingError: error, ratingStats: { ...defaultRatingStats } });
-    }
   }
 
   handleGroanClick = async (value) => {
@@ -197,11 +201,12 @@ class OpenAIData extends React.Component {
         throw new Error(payload.error || 'Unable to save rating');
       }
       const data = await response.json();
-      this.setState({
+      this.setState(prev => ({
         ratingStats: normalizeStats(data),
         hasSubmittedRating: true,
-        ratingError: null
-      });
+        ratingError: null,
+        globalVotes: prev.globalVotes !== null ? prev.globalVotes + 1 : null
+      }));
       this.incrementStreak(currentJokeId);
     } catch (error) {
       this.setState({ ratingError: error });
@@ -424,7 +429,8 @@ class OpenAIData extends React.Component {
       submitMessage,
       streakCount,
       jokesExhausted,
-      exhaustedMessage
+      exhaustedMessage,
+      globalVotes
     } = this.state;
 
     const displayQuestionTokens =
@@ -468,7 +474,14 @@ class OpenAIData extends React.Component {
     }
     return (
       <div className={styles.jokeContainer}>
-        <h2 className={styles.jokeHeader}>Fresh Groaners</h2>
+        <div className={styles.jokeHeaderRow}>
+          <h2 className={styles.jokeHeader}>Fresh Groaners</h2>
+          {globalVotes !== null && (
+            <span className={styles.globalVotesStat} aria-live="polite">
+              🗳️ {globalVotes.toLocaleString()} groans cast
+            </span>
+          )}
+        </div>
         {displayQuestionTokens.length > 0 && (
           <p className={styles.question}>
             {displayQuestionTokens.map((t, i) => (
@@ -564,7 +577,18 @@ class OpenAIData extends React.Component {
                   <p>Cast your vote to reveal the crowd rating.</p>
                 )}
                 {hasSubmittedRating && (
-                  <p className={styles.ratingThanks}>Thanks for letting us know how much you groaned!</p>
+                  <>
+                    <p className={styles.ratingThanks}>Thanks for letting us know how much you groaned!</p>
+                    {(() => {
+                      const next = nextStreakMilestone(streakCount);
+                      if (!next) return null;
+                      return (
+                        <p className={styles.streakNudge}>
+                          ⚡ {next.remaining} more {next.remaining === 1 ? 'groan' : 'groans'} to hit your {next.milestone}-vote streak!
+                        </p>
+                      );
+                    })()}
+                  </>
                 )}
                 {ratingError && (
                   <p className={styles.ratingError}>We couldn&apos;t save your rating. Please try again.</p>
@@ -659,6 +683,15 @@ class OpenAIData extends React.Component {
 }
 
 export default function Home() {
+  const [featuredJoke, setFeaturedJoke] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch('/api/featured-joke')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data && data.opener) setFeaturedJoke(data); })
+      .catch(() => {});
+  }, []);
+
   const navLinks = [
     { href: '/', label: 'Live Jokes' },
     { href: '/top', label: 'Top Jokes' },
@@ -767,6 +800,31 @@ export default function Home() {
           <span className={styles.sourcePill}>Community</span>
         </div>
       </section>
+
+      {featuredJoke && (
+        <section className={styles.featuredJokeSection}>
+          <div className={styles.featuredJokeCard}>
+            <span className={styles.featuredBadge}>⭐ Top Community Groaner</span>
+            <p className={styles.featuredQuestion}>{featuredJoke.opener}</p>
+            {featuredJoke.punchline && (
+              <p className={styles.featuredAnswer}>{featuredJoke.punchline}</p>
+            )}
+            <div className={styles.featuredMeta}>
+              {featuredJoke.author && (
+                <span className={styles.featuredAuthor}>{featuredJoke.author}</span>
+              )}
+              <span className={styles.featuredStats}>
+                ⭐ {featuredJoke.average} avg · {featuredJoke.totalRatings} votes
+              </span>
+              {featuredJoke.jokeId && (
+                <Link href={`/joke/${featuredJoke.jokeId}`} className={styles.featuredLink}>
+                  Rate it →
+                </Link>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
 
       <main className={styles.main}>
         <OpenAIData />

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -185,17 +185,125 @@
   color: var(--color-text);
 }
 
+.jokeHeaderRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 2px solid rgba(243, 156, 18, 0.4);
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
 .jokeHeader {
   font-size: 2rem;
-  margin-bottom: 1rem;
+  margin: 0;
   text-align: left;
   font-weight: 800;
   background: linear-gradient(135deg, #f8fafc 0%, #cbd5e1 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-  border-bottom: 2px solid rgba(243, 156, 18, 0.4);
-  padding-bottom: 0.5rem;
+}
+
+.globalVotesStat {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.4);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  animation: fadeIn 0.4s ease-in forwards;
+}
+
+.streakNudge {
+  margin: 0.3rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(243, 156, 18, 0.75);
+  font-weight: 500;
+}
+
+/* Featured top joke */
+.featuredJokeSection {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 2rem 1rem;
+  animation: fadeIn 0.5s ease-in forwards;
+}
+
+.featuredJokeCard {
+  background: linear-gradient(135deg, rgba(243, 156, 18, 0.07) 0%, rgba(243, 156, 18, 0.02) 100%);
+  border: 1px solid rgba(243, 156, 18, 0.28);
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 2px 16px rgba(243, 156, 18, 0.07);
+}
+
+.featuredBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: rgba(243, 156, 18, 0.85);
+  background: rgba(243, 156, 18, 0.1);
+  border: 1px solid rgba(243, 156, 18, 0.22);
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+  margin-bottom: 0.65rem;
+}
+
+.featuredQuestion {
+  font-weight: 600;
+  font-size: 1.05rem;
+  margin: 0 0 0.25rem;
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.featuredAnswer {
+  font-size: 1rem;
+  margin: 0 0 0.75rem;
+  color: rgba(226, 232, 240, 0.8);
+  line-height: 1.5;
+}
+
+.featuredMeta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.82rem;
+}
+
+.featuredAuthor {
+  color: rgba(226, 232, 240, 0.45);
+}
+
+.featuredStats {
+  color: rgba(243, 156, 18, 0.65);
+  font-weight: 600;
+}
+
+.featuredLink {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.82rem;
+}
+
+.featuredLink:hover {
+  text-decoration: underline;
+  color: #f7dc6f;
+}
+
+@media (max-width: 640px) {
+  .featuredJokeSection {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
 }
 
 /* Container used to center the loading message when no data has been loaded yet */


### PR DESCRIPTION
- Live vote counter: fetches global total from new /api/global-stats and
  increments optimistically after each vote; displayed subtly in the joke header row
- Featured top joke: new /api/featured-joke endpoint picks a random top-rated
  joke from the STATS_TABLE TOP_PERFORMERS GSI; displayed above the main joke
  section with rating stats and a link to rate it
- Streak nudge: after voting, shows how many more groans until the next
  milestone (5, 10, 25, 50, 100-vote streaks) to encourage continued engagement
- Bug fix: removed the redundant GET /api/ratings call on joke load — stats are
  never shown before voting, and the POST response already returns updated stats,
  so the pre-fetch was a wasted request on every page load
- Adds readGlobalStats() and getRandomTopJoke() to ratingsStorageDynamo.js

https://claude.ai/code/session_01Bs3i2aVRGkDMAJfj3P8Mnb