### PR TITLE
Fix joke count on dashboard and reduce homepage loading jumpiness

### DIFF
--- a/lib/ratingsStorageDynamo.js
+++ b/lib/ratingsStorageDynamo.js
@@ -294,12 +294,31 @@ export async function getWeeklyTopJokes() {
     .slice(0, 20)
 }
 
+// Count all jokes that have stats entries in STATS_TABLE GSI1
+async function countAllRatedJokes(client) {
+  let count = 0;
+  let lastKey;
+  do {
+    const result = await client.send(new QueryCommand({
+      TableName: STATS_TABLE,
+      IndexName: 'GSI1',
+      KeyConditionExpression: 'GSI1PK = :pk',
+      ExpressionAttributeValues: { ':pk': 'TOP_PERFORMERS' },
+      Select: 'COUNT',
+      ...(lastKey ? { ExclusiveStartKey: lastKey } : {})
+    }));
+    count += result.Count || 0;
+    lastKey = result.LastEvaluatedKey;
+  } while (lastKey);
+  return count;
+}
+
 // O(1) read for dashboard - pre-computed global stats
 export async function getDashboardStats() {
   const client = getDynamoClient();
 
-  // All 4 queries run in parallel
-  const [globalItem, authorsResult, topResult, recentResult] = await Promise.all([
+  // All queries run in parallel
+  const [globalItem, authorsResult, topResult, recentResult, uniqueJokesCount] = await Promise.all([
     readGlobalItem(client),
 
     // Author stats (query all AUTHOR# sort keys)
@@ -322,12 +341,14 @@ export async function getDashboardStats() {
       ExpressionAttributeValues: { ':pk': 'ALL_RATINGS' },
       ScanIndexForward: false,
       Limit: 20
-    }))
+    })),
+
+    countAllRatedJokes(client)
   ]);
 
   const { totalRatings: overallRatings, overallAverage, ratingCounts } = parseGlobalItem(globalItem);
   const topPerformers = topResult.items;
-  const uniqueJokes = topResult.count;
+  const uniqueJokes = uniqueJokesCount;
 
   const authors = (authorsResult.Items || []).map(item => ({
     author: item.author || item.SK.replace('AUTHOR#', ''),

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -243,6 +243,11 @@ export default function Dashboard({ summary, error, requestTimeMs, generatedAt }
                   {crowdFavorite.author && (
                     <span className={styles.spotlightAuthor}>by {formatAuthorName(crowdFavorite.author)}</span>
                   )}
+                  {crowdFavorite.jokeId && (
+                    <Link href={`/joke/${crowdFavorite.jokeId}`} className={styles.spotlightLink}>
+                      View &amp; rate →
+                    </Link>
+                  )}
                 </div>
               </section>
             )}
@@ -290,8 +295,9 @@ export default function Dashboard({ summary, error, requestTimeMs, generatedAt }
                 </p>
                 <div className={styles.leaderboard}>
                   {topPerformers.slice(0, 5).map((performer, index) => (
-                    <div
+                    <Link
                       key={`${performer.jokeId || index}`}
+                      href={`/joke/${performer.jokeId}`}
                       className={`${styles.leaderboardItem} ${index === 0 ? styles.gold : ''} ${index === 1 ? styles.silver : ''} ${index === 2 ? styles.bronze : ''}`}
                     >
                       <div className={styles.leaderboardRank}>#{index + 1}</div>
@@ -308,7 +314,7 @@ export default function Dashboard({ summary, error, requestTimeMs, generatedAt }
                           )}
                         </div>
                       </div>
-                    </div>
+                    </Link>
                   ))}
                 </div>
               </section>
@@ -368,6 +374,11 @@ export default function Dashboard({ summary, error, requestTimeMs, generatedAt }
                         <div className={styles.activityMeta}>
                           <span>{formatDate(item.submittedAt || item.date)}</span>
                           {item.author && <span>{formatAuthorName(item.author)}</span>}
+                          {item.jokeId && (
+                            <Link href={`/joke/${item.jokeId}`} className={styles.activityLink}>
+                              View →
+                            </Link>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -450,7 +450,14 @@ class OpenAIData extends React.Component {
       return <div>Error Loading: {error.message}</div>;
     }
     if (!isLoaded) {
-      return <Spinner />;
+      return (
+        <div className={styles.jokeContainer}>
+          <div className={styles.jokeHeaderRow}>
+            <h2 className={styles.jokeHeader}>Fresh Groaners</h2>
+          </div>
+          <Spinner />
+        </div>
+      );
     }
     if (jokesExhausted) {
       return (
@@ -684,12 +691,16 @@ class OpenAIData extends React.Component {
 
 export default function Home() {
   const [featuredJoke, setFeaturedJoke] = React.useState(null);
+  const [featuredLoading, setFeaturedLoading] = React.useState(true);
 
   React.useEffect(() => {
     fetch('/api/featured-joke')
       .then(r => r.ok ? r.json() : null)
-      .then(data => { if (data && data.opener) setFeaturedJoke(data); })
-      .catch(() => {});
+      .then(data => {
+        if (data && data.opener) setFeaturedJoke(data);
+        setFeaturedLoading(false);
+      })
+      .catch(() => { setFeaturedLoading(false); });
   }, []);
 
   const navLinks = [
@@ -801,28 +812,36 @@ export default function Home() {
         </div>
       </section>
 
-      {featuredJoke && (
+      {(featuredLoading || featuredJoke) && (
         <section className={styles.featuredJokeSection}>
-          <div className={styles.featuredJokeCard}>
-            <span className={styles.featuredBadge}>⭐ Top Community Groaner</span>
-            <p className={styles.featuredQuestion}>{featuredJoke.opener}</p>
-            {featuredJoke.punchline && (
-              <p className={styles.featuredAnswer}>{featuredJoke.punchline}</p>
-            )}
-            <div className={styles.featuredMeta}>
-              {featuredJoke.author && (
-                <span className={styles.featuredAuthor}>{featuredJoke.author}</span>
-              )}
-              <span className={styles.featuredStats}>
-                ⭐ {featuredJoke.average} avg · {featuredJoke.totalRatings} votes
-              </span>
-              {featuredJoke.jokeId && (
-                <Link href={`/joke/${featuredJoke.jokeId}`} className={styles.featuredLink}>
-                  Rate it →
-                </Link>
-              )}
+          {featuredLoading ? (
+            <div className={`${styles.featuredJokeCard} ${styles.featuredJokeSkeleton}`}>
+              <span className={styles.featuredBadge}>⭐ Top Community Groaner</span>
+              <div className={styles.skeletonLine} style={{ width: '80%', height: '1.2em', marginBottom: '0.5rem' }} />
+              <div className={styles.skeletonLine} style={{ width: '60%', height: '1em' }} />
             </div>
-          </div>
+          ) : (
+            <div className={styles.featuredJokeCard}>
+              <span className={styles.featuredBadge}>⭐ Top Community Groaner</span>
+              <p className={styles.featuredQuestion}>{featuredJoke.opener}</p>
+              {featuredJoke.punchline && (
+                <p className={styles.featuredAnswer}>{featuredJoke.punchline}</p>
+              )}
+              <div className={styles.featuredMeta}>
+                {featuredJoke.author && (
+                  <span className={styles.featuredAuthor}>{featuredJoke.author}</span>
+                )}
+                <span className={styles.featuredStats}>
+                  ⭐ {featuredJoke.average} avg · {featuredJoke.totalRatings} votes
+                </span>
+                {featuredJoke.jokeId && (
+                  <Link href={`/joke/${featuredJoke.jokeId}`} className={styles.featuredLink}>
+                    Rate it →
+                  </Link>
+                )}
+              </div>
+            </div>
+          )}
         </section>
       )}
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -805,10 +805,10 @@ export default function Home() {
           submit your own, or let AI generate a fresh one on the spot.
         </p>
         <div className={styles.sourcePills}>
-          <span className={styles.sourcePill}>fatherhood.gov</span>
-          <span className={styles.sourcePill}>icanhazdadjoke.com</span>
-          <span className={styles.sourcePill}>r/dadjokes</span>
-          <span className={styles.sourcePill}>Community</span>
+          <Link href="/author/fatherhood.gov" className={styles.sourcePill}>fatherhood.gov</Link>
+          <Link href="/author/icanhazdadjoke.com" className={styles.sourcePill}>icanhazdadjoke.com</Link>
+          <Link href={`/author/${encodeURIComponent('reddit.com/r/dadjokes')}`} className={styles.sourcePill}>r/dadjokes</Link>
+          <Link href="/submit" className={styles.sourcePill}>Community</Link>
         </div>
       </section>
 

--- a/styles/Dashboard.module.css
+++ b/styles/Dashboard.module.css
@@ -191,6 +191,20 @@
   font-style: italic;
 }
 
+.spotlightLink {
+  color: #fbbf24;
+  text-decoration: none;
+  font-weight: 600;
+  font-style: normal;
+  border-bottom: 1px solid rgba(251, 191, 36, 0.4);
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.spotlightLink:hover {
+  color: #fde68a;
+  border-color: rgba(251, 191, 36, 0.8);
+}
+
 /* Star Rating */
 .starRating {
   color: #fbbf24;
@@ -306,6 +320,8 @@
   border-radius: 12px;
   padding: 1.25rem;
   transition: transform 0.2s, border-color 0.2s;
+  text-decoration: none;
+  color: inherit;
 }
 
 .leaderboardItem:hover {
@@ -497,6 +513,19 @@
   gap: 1rem;
   font-size: 0.8rem;
   color: rgba(226, 232, 240, 0.5);
+  align-items: center;
+}
+
+.activityLink {
+  color: rgba(243, 156, 18, 0.8);
+  text-decoration: none;
+  margin-left: auto;
+  font-weight: 500;
+  transition: color 0.15s;
+}
+
+.activityLink:hover {
+  color: rgba(243, 156, 18, 1);
 }
 
 /* Empty State */

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -828,6 +828,14 @@
   font-weight: 600;
   padding: 0.3rem 0.75rem;
   border-radius: 999px;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+a.sourcePill:hover {
+  background: rgba(243, 156, 18, 0.22);
+  border-color: rgba(243, 156, 18, 0.55);
+  color: rgba(243, 156, 18, 1);
 }
 
 /* Shared section styles */

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -228,7 +228,6 @@
   max-width: 800px;
   margin: 0 auto;
   padding: 0 2rem 1rem;
-  animation: fadeIn 0.5s ease-in forwards;
 }
 
 .featuredJokeCard {
@@ -237,6 +236,25 @@
   border-radius: 14px;
   padding: 1.25rem 1.5rem;
   box-shadow: 0 2px 16px rgba(243, 156, 18, 0.07);
+  animation: fadeIn 0.4s ease-in forwards;
+}
+
+.featuredJokeSkeleton {
+  animation: none;
+  opacity: 0.5;
+}
+
+.skeletonLine {
+  background: linear-gradient(90deg, rgba(243, 156, 18, 0.1) 25%, rgba(243, 156, 18, 0.2) 50%, rgba(243, 156, 18, 0.1) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite;
+  border-radius: 4px;
+  display: block;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
 .featuredBadge {


### PR DESCRIPTION
- Dashboard: replace result.Count (capped at query limit=8) with a real
  paginated COUNT query on the TOP_PERFORMERS GSI, so "Jokes Rated" shows
  the actual number of unique jokes that have been rated
- Homepage: wrap loading spinner in the jokeContainer so layout doesn't shift
  when the joke loads in; add skeleton placeholder for featured joke card
  while it fetches so the section doesn't pop in from nothing

https://claude.ai/code/session_013XssvVWeM9uyH3YGQRtrL1