### PR TITLE
Add dashboard metrics, low-rating filter, and NSFW FAQ

### DIFF
--- a/lib/ratingsStorageDynamo.js
+++ b/lib/ratingsStorageDynamo.js
@@ -225,6 +225,33 @@ async function readTopPerformers(client, limit = 8, minAverage = null) {
   return { items, count: result.Count || 0 };
 }
 
+// Returns the set of joke IDs that have a low average rating (below maxAverage)
+// and enough ratings to be statistically significant (minRatings).
+// Used to filter these jokes out of the random joke pool.
+export async function getLowRatedJokeIds(maxAverage = 1.5, minRatings = 3) {
+  try {
+    const client = getDynamoClient();
+    const result = await client.send(new QueryCommand({
+      TableName: STATS_TABLE,
+      IndexName: 'GSI1',
+      KeyConditionExpression: 'GSI1PK = :pk AND GSI1SK <= :maxAvg',
+      ExpressionAttributeValues: {
+        ':pk': 'TOP_PERFORMERS',
+        ':maxAvg': maxAverage
+      },
+      ScanIndexForward: true
+    }));
+    return new Set(
+      (result.Items || [])
+        .filter(item => (item.totalRatings || 0) >= minRatings)
+        .map(item => item.PK.replace('STATS#', ''))
+    );
+  } catch (error) {
+    console.error('[ratings] Failed to load low-rated joke IDs, failing open', { error });
+    return new Set();
+  }
+}
+
 // ─── Public exports ───────────────────────────────────────────────────────────
 
 // O(1) read for global totals — used by homepage live counter

--- a/lib/ratingsStorageDynamo.js
+++ b/lib/ratingsStorageDynamo.js
@@ -254,6 +254,15 @@ export async function getLowRatedJokeIds(maxAverage = 1.5, minRatings = 3) {
 
 // ─── Public exports ───────────────────────────────────────────────────────────
 
+// Fetch top N jokes by average rating (min 3 votes) — used by /top page
+export async function getTopJokes(limit = 25) {
+  const client = getDynamoClient();
+  const { items } = await readTopPerformers(client, limit + 20); // over-fetch to account for minRatings filter
+  return items
+    .filter(j => j.joke)
+    .slice(0, limit);
+}
+
 // O(1) read for global totals — used by homepage live counter
 export async function readGlobalStats() {
   const client = getDynamoClient();

--- a/pages/404.js
+++ b/pages/404.js
@@ -6,7 +6,7 @@ import styles from '../styles/NotFound.module.css'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]
@@ -78,7 +78,7 @@ export default function NotFound() {
 
         <div className={styles.actions}>
           <Link href="/" className={styles.primaryButton}>Take Me Home</Link>
-          <Link href="/top" className={styles.secondaryButton}>Top Jokes</Link>
+          <Link href="/best-dad-jokes" className={styles.secondaryButton}>Top Jokes</Link>
         </div>
       </main>
     </div>

--- a/pages/about.js
+++ b/pages/about.js
@@ -137,6 +137,22 @@ export default function About() {
           </p>
         </section>
 
+        <section className={styles.section}>
+          <h2>FAQ</h2>
+          <div className={styles.faqList}>
+            <div className={styles.faqItem}>
+              <h3>What about inappropriate content?</h3>
+              <p>
+                We do our best to filter out NSFW content automatically, but some may occasionally
+                slip through. We&apos;re constantly working to keep this site clean and fun for everyone.
+                If you run across a joke that doesn&apos;t belong here, give it a 1-star rating — we
+                automatically filter out jokes that consistently receive low ratings, so your vote
+                helps keep the collection clean and groan-worthy for the whole family.
+              </p>
+            </div>
+          </div>
+        </section>
+
         <section className={styles.cta}>
           <h2>Ready to Judge?</h2>
           <p>900+ jokes are waiting for your verdict. One groan at a time.</p>

--- a/pages/about.js
+++ b/pages/about.js
@@ -5,7 +5,7 @@ import styles from '../styles/About.module.css'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]

--- a/pages/api/random-joke.js
+++ b/pages/api/random-joke.js
@@ -1,5 +1,5 @@
 import { getAllJokesAsync } from '../../lib/jokesData'
-import { getVotedJokeIds, getFlaggedJokeIds, flagJokeAsNsfw } from '../../lib/ratingsStorageDynamo'
+import { getVotedJokeIds, getFlaggedJokeIds, flagJokeAsNsfw, getLowRatedJokeIds } from '../../lib/ratingsStorageDynamo'
 import { isNsfw } from '../../lib/nsfwFilter'
 
 const EXHAUSTED_MESSAGE =
@@ -36,13 +36,14 @@ function getIp(req) {
 export default async function handler(req, res) {
   try {
     const ip = getIp(req)
-    const [allJokes, votedIds, flaggedIds] = await Promise.all([
+    const [allJokes, votedIds, flaggedIds, lowRatedIds] = await Promise.all([
       getAllJokesAsync(),
       getVotedJokeIds(ip),
-      getFlaggedJokeIds()
+      getFlaggedJokeIds(),
+      getLowRatedJokeIds(1.5, 3)
     ])
 
-    const excluded = new Set([...votedIds, ...flaggedIds])
+    const excluded = new Set([...votedIds, ...flaggedIds, ...lowRatedIds])
     let candidates = excluded.size > 0
       ? allJokes.filter((j) => !excluded.has(j.id))
       : allJokes.slice()

--- a/pages/author/[author].js
+++ b/pages/author/[author].js
@@ -8,7 +8,7 @@ import styles from '../../styles/Author.module.css'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]

--- a/pages/best-dad-jokes.js
+++ b/pages/best-dad-jokes.js
@@ -7,7 +7,7 @@ import { getTopJokes, readGlobalStats } from '../lib/ratingsStorageDynamo'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]
@@ -65,14 +65,14 @@ export default function TopJokes({ jokes, totalRatings, updatedAt, error }) {
         "@type": "BreadcrumbList",
         "itemListElement": [
           { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://joshkurz.net/" },
-          { "@type": "ListItem", "position": 2, "name": "Top Dad Jokes", "item": "https://joshkurz.net/top" }
+          { "@type": "ListItem", "position": 2, "name": "Top Dad Jokes", "item": "https://joshkurz.net/best-dad-jokes" }
         ]
       },
       {
         "@type": "ItemList",
         "name": `Top ${jokes.length} Dad Jokes Ranked by Community Votes`,
         "description": "The highest-rated dad jokes from 900+ in the collection, ranked by average star rating with a minimum of 3 votes.",
-        "url": "https://joshkurz.net/top",
+        "url": "https://joshkurz.net/best-dad-jokes",
         "numberOfItems": jokes.length,
         "itemListElement": jokes.map((j, i) => ({
           "@type": "ListItem",
@@ -99,9 +99,9 @@ export default function TopJokes({ jokes, totalRatings, updatedAt, error }) {
       <Head>
         <title>{`Top ${jokes.length} Dad Jokes Ranked by Community Votes | JoshKurz.net`}</title>
         <meta name="description" content={metaDescription} />
-        <link rel="canonical" href="https://joshkurz.net/top" />
+        <link rel="canonical" href="https://joshkurz.net/best-dad-jokes" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://joshkurz.net/top" />
+        <meta property="og:url" content="https://joshkurz.net/best-dad-jokes" />
         <meta property="og:title" content={`Top ${jokes.length} Dad Jokes Ranked by Community Votes`} />
         <meta property="og:description" content={metaDescription} />
         <meta property="og:site_name" content="JoshKurz.net Dad Jokes" />

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -8,7 +8,7 @@ import { getAllJokesAsync } from '../lib/jokesData'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import Header from '../components/Header'
 import styles from '../styles/Dashboard.module.css'
 import { getDashboardStats } from '../lib/ratingsStorageDynamo'
+import { getAllJokesAsync } from '../lib/jokesData'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
@@ -151,7 +152,7 @@ RatingDistributionChart.propTypes = {
   counts: PropTypes.object
 }
 
-export default function Dashboard({ summary, error, requestTimeMs, generatedAt }) {
+export default function Dashboard({ summary, totalJokes, error, requestTimeMs, generatedAt }) {
   const authorStats = summary?.totals?.byAuthor || []
   const topAuthor = authorStats[0] || null
   const authorCount = authorStats.length
@@ -164,6 +165,10 @@ export default function Dashboard({ summary, error, requestTimeMs, generatedAt }
   const oneStarCount = summary?.ratingDistribution?.overall?.[1] || 0
   const totalRatings = summary?.totals?.overallRatings || 0
   const positivePercentage = totalRatings > 0 ? Math.round((fiveStarCount / totalRatings) * 100) : 0
+
+  // Coverage metrics
+  const uniqueJokes = summary?.totals?.uniqueJokes || 0
+  const percentRated = totalJokes > 0 ? Math.round((uniqueJokes / totalJokes) * 100) : 0
 
   return (
     <div className={styles.container}>
@@ -225,6 +230,14 @@ export default function Dashboard({ summary, error, requestTimeMs, generatedAt }
                 <div className={styles.statBox}>
                   <div className={styles.statValue}>{positivePercentage}%</div>
                   <div className={styles.statLabel}>5-Star Ratings</div>
+                </div>
+                <div className={styles.statBox}>
+                  <div className={styles.statValue}>{formatNumber(totalJokes)}</div>
+                  <div className={styles.statLabel}>Total Jokes</div>
+                </div>
+                <div className={styles.statBox}>
+                  <div className={styles.statValue}>{percentRated}%</div>
+                  <div className={styles.statLabel}>Jokes Rated</div>
                 </div>
               </div>
             </section>
@@ -447,6 +460,7 @@ Dashboard.propTypes = {
       })
     )
   }),
+  totalJokes: PropTypes.number,
   error: PropTypes.bool,
   requestTimeMs: PropTypes.number,
   generatedAt: PropTypes.string
@@ -454,6 +468,7 @@ Dashboard.propTypes = {
 
 Dashboard.defaultProps = {
   summary: null,
+  totalJokes: 0,
   error: false,
   requestTimeMs: 0,
   generatedAt: ''
@@ -462,13 +477,17 @@ Dashboard.defaultProps = {
 export async function getServerSideProps() {
   const startTime = Date.now()
   try {
-    // Call getDashboardStats directly - no caching
-    const summary = await getDashboardStats()
+    const [summary, allJokes] = await Promise.all([
+      getDashboardStats(),
+      getAllJokesAsync()
+    ])
+    const totalJokes = allJokes.length
     const requestTimeMs = Date.now() - startTime
     const generatedAt = new Date().toISOString()
     return {
       props: {
         summary,
+        totalJokes,
         requestTimeMs,
         generatedAt
       }
@@ -479,6 +498,7 @@ export async function getServerSideProps() {
     return {
       props: {
         summary: null,
+        totalJokes: 0,
         error: true,
         requestTimeMs,
         generatedAt: new Date().toISOString()

--- a/pages/guide.js
+++ b/pages/guide.js
@@ -5,7 +5,7 @@ import styles from '../styles/GuidePage.module.css'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]
@@ -190,7 +190,7 @@ export default function GuidePage() {
               icanhazdadjoke.com&apos;s community API, the all-time top posts from Reddit&apos;s
               r/dadjokes, and original submissions from visitors like you. The community rates every
               joke, and the top performers surface in the{' '}
-              <Link href="/top" className={styles.link || 'a'} style={{ color: 'var(--color-primary)', textDecoration: 'underline' }}>
+              <Link href="/best-dad-jokes" className={styles.link || 'a'} style={{ color: 'var(--color-primary)', textDecoration: 'underline' }}>
                 Hall of Fame
               </Link>.
             </p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -705,7 +705,7 @@ export default function Home() {
 
   const navLinks = [
     { href: '/', label: 'Live Jokes' },
-    { href: '/top', label: 'Top Jokes' },
+    { href: '/best-dad-jokes', label: 'Top Jokes' },
     { href: '/dashboard', label: 'Dashboard' },
     { href: '/about', label: 'About' },
   ];
@@ -861,7 +861,7 @@ export default function Home() {
           <div className={styles.step}>
             <div className={styles.stepIcon}>🤦‍♂️</div>
             <h3>Rate the Groan Factor</h3>
-            <p>Give it 1–5 groans. One reluctant chuckle or a full eye-roll? Your vote is saved and contributes to the community leaderboard on the <Link href="/top" className={styles.inlineLink}>Top Jokes</Link> page.</p>
+            <p>Give it 1–5 groans. One reluctant chuckle or a full eye-roll? Your vote is saved and contributes to the community leaderboard on the <Link href="/best-dad-jokes" className={styles.inlineLink}>Top Jokes</Link> page.</p>
           </div>
           <div className={styles.step}>
             <div className={styles.stepIcon}>🤖</div>
@@ -910,7 +910,7 @@ export default function Home() {
           </div>
           <div className={styles.faqItem}>
             <dt>Can I submit my own dad joke?</dt>
-            <dd>Yes! Click &ldquo;Submit Your Joke&rdquo; below any joke to add yours. Community votes determine which jokes rise to the top of the <Link href="/top" className={styles.inlineLink}>leaderboard</Link>.</dd>
+            <dd>Yes! Click &ldquo;Submit Your Joke&rdquo; below any joke to add yours. Community votes determine which jokes rise to the top of the <Link href="/best-dad-jokes" className={styles.inlineLink}>leaderboard</Link>.</dd>
           </div>
           <div className={styles.faqItem}>
             <dt>How does the AI dad joke generator work?</dt>

--- a/pages/joke/[id].js
+++ b/pages/joke/[id].js
@@ -9,7 +9,7 @@ import { getAllJokesAsync } from '../../lib/jokesData'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]

--- a/pages/jokes/[category].js
+++ b/pages/jokes/[category].js
@@ -7,7 +7,7 @@ import { CATEGORIES, CATEGORY_META } from '../../lib/categories'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -4,7 +4,7 @@ const SITE_URL = 'https://joshkurz.net'
 
 const STATIC_PAGES = [
   { url: '/',        changefreq: 'daily',   priority: '1.0' },
-  { url: '/top',     changefreq: 'daily',   priority: '0.9' },
+  { url: '/best-dad-jokes', changefreq: 'daily', priority: '0.9' },
   { url: '/weekly',  changefreq: 'weekly',  priority: '0.85' },
   { url: '/submit',  changefreq: 'monthly', priority: '0.75' },
   { url: '/dashboard', changefreq: 'daily', priority: '0.8' },

--- a/pages/speak.js
+++ b/pages/speak.js
@@ -16,7 +16,7 @@ export default function SpeechHelper() {
 
   const navLinks = [
     { href: '/', label: 'Live Jokes' },
-    { href: '/top', label: 'Top Jokes' },
+    { href: '/best-dad-jokes', label: 'Top Jokes' },
     { href: '/dashboard', label: 'Dashboard' },
     { href: '/about', label: 'About' },
   ];

--- a/pages/submit.js
+++ b/pages/submit.js
@@ -6,7 +6,7 @@ import styles from '../styles/SubmitPage.module.css'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]
@@ -147,7 +147,7 @@ export default function SubmitPage() {
             <Link href="/guide" className={styles.link}>What Makes a Great Dad Joke?</Link>
           </p>
           <p>
-            Or browse the <Link href="/top" className={styles.link}>community hall of fame</Link> for inspiration.
+            Or browse the <Link href="/best-dad-jokes" className={styles.link}>community hall of fame</Link> for inspiration.
           </p>
         </div>
       </main>

--- a/pages/top.js
+++ b/pages/top.js
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import PropTypes from 'prop-types'
 import Header from '../components/Header'
 import styles from '../styles/Top.module.css'
-import { getDashboardStats } from '../lib/ratingsStorageDynamo'
+import { getTopJokes, readGlobalStats } from '../lib/ratingsStorageDynamo'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
@@ -53,42 +53,70 @@ function rankClass(index) {
 }
 
 export default function TopJokes({ jokes, totalRatings, updatedAt, error }) {
+  const topJoke = jokes[0] || null
+  const metaDescription = topJoke
+    ? `The ${jokes.length} best dad jokes ranked by real community votes. #1: "${topJoke.joke?.slice(0, 80)}..." — rated ${topJoke.average?.toFixed(2)} stars from ${formatNumber(totalRatings)} total ratings.`
+    : `The best dad jokes ranked by real community votes. ${formatNumber(totalRatings)} ratings cast across 900+ jokes. Updated live.`
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://joshkurz.net/" },
+          { "@type": "ListItem", "position": 2, "name": "Top Dad Jokes", "item": "https://joshkurz.net/top" }
+        ]
+      },
+      {
+        "@type": "ItemList",
+        "name": `Top ${jokes.length} Dad Jokes Ranked by Community Votes`,
+        "description": "The highest-rated dad jokes from 900+ in the collection, ranked by average star rating with a minimum of 3 votes.",
+        "url": "https://joshkurz.net/top",
+        "numberOfItems": jokes.length,
+        "itemListElement": jokes.map((j, i) => ({
+          "@type": "ListItem",
+          "position": i + 1,
+          "item": {
+            "@type": "CreativeWork",
+            "name": j.joke ? j.joke.slice(0, 110) : `Dad Joke #${i + 1}`,
+            "description": j.joke || '',
+            "aggregateRating": {
+              "@type": "AggregateRating",
+              "ratingValue": j.average,
+              "ratingCount": j.totalRatings,
+              "bestRating": 5,
+              "worstRating": 1
+            }
+          }
+        }))
+      }
+    ]
+  }
+
   return (
     <div className={styles.container}>
       <Head>
-        <title>Top Rated Dad Jokes - Community Hall of Fame</title>
-        <meta name="description" content={`The highest-rated dad jokes ranked by community votes. ${jokes.length > 0 ? `${jokes.length} top performers` : 'Community'} voted best from 900+ jokes. Updated in real time.`} />
+        <title>{`Top ${jokes.length} Dad Jokes Ranked by Community Votes | JoshKurz.net`}</title>
+        <meta name="description" content={metaDescription} />
         <link rel="canonical" href="https://joshkurz.net/top" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://joshkurz.net/top" />
-        <meta property="og:title" content="Top Rated Dad Jokes - Community Hall of Fame" />
-        <meta property="og:description" content="The highest-rated dad jokes ranked by community votes. See which jokes made people groan the most." />
+        <meta property="og:title" content={`Top ${jokes.length} Dad Jokes Ranked by Community Votes`} />
+        <meta property="og:description" content={metaDescription} />
         <meta property="og:site_name" content="JoshKurz.net Dad Jokes" />
         <meta property="og:image" content="https://joshkurz.net/og-image.png" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:image" content="https://joshkurz.net/og-image.png" />
-        <meta name="twitter:title" content="Top Rated Dad Jokes - Community Hall of Fame" />
-        <meta name="twitter:description" content="The highest-rated dad jokes ranked by community votes. See which jokes made people groan the most." />
+        <meta name="twitter:title" content={`Top ${jokes.length} Dad Jokes Ranked by Community Votes`} />
+        <meta name="twitter:description" content={metaDescription} />
         {jokes.length > 0 && (
-          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
-            "@context": "https://schema.org",
-            "@type": "ItemList",
-            "name": "Top Rated Dad Jokes",
-            "description": "The highest-rated dad jokes ranked by community votes",
-            "url": "https://joshkurz.net/top",
-            "numberOfItems": jokes.length,
-            "itemListElement": jokes.slice(0, 10).map((j, i) => ({
-              "@type": "ListItem",
-              "position": i + 1,
-              "item": {
-                "@type": "CreativeWork",
-                "name": j.joke ? j.joke.slice(0, 80) : `Joke #${i + 1}`,
-                "description": j.joke || '',
-              }
-            }))
-          })}} />
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+          />
         )}
       </Head>
 
@@ -97,10 +125,10 @@ export default function TopJokes({ jokes, totalRatings, updatedAt, error }) {
       <main className={styles.main}>
         <section className={styles.hero}>
           <span className={styles.heroLabel}>Hall of Fame</span>
-          <h1>Top Rated Dad Jokes</h1>
+          <h1>Top {jokes.length} Dad Jokes</h1>
           <p className={styles.heroSubtitle}>
-            The community has spoken. These are the jokes that earned the most groans —
-            ranked by average rating from {formatNumber(totalRatings)} total votes.
+            Community-ranked from {formatNumber(totalRatings)} real votes across 900+ jokes.
+            Only jokes with at least 3 ratings qualify — no flukes, just proven groan-worthy gold.
           </p>
         </section>
 
@@ -177,25 +205,23 @@ TopJokes.defaultProps = {
   error: false,
 }
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   try {
-    const summary = await getDashboardStats()
-    const jokes = (summary?.topPerformers || []).filter(
-      (j) => j.mode !== 'daily' && j.joke
-    )
+    const [jokes, globalStats] = await Promise.all([
+      getTopJokes(25),
+      readGlobalStats(),
+    ])
     return {
       props: {
         jokes,
-        totalRatings: summary?.totals?.overallRatings || 0,
+        totalRatings: globalStats.totalRatings || 0,
         updatedAt: new Date().toISOString(),
         error: false,
       },
-      revalidate: 3600, // ISR: rebuild at most once per hour
     }
   } catch {
     return {
       props: { jokes: [], totalRatings: 0, updatedAt: null, error: true },
-      revalidate: 60,
     }
   }
 }

--- a/pages/weekly.js
+++ b/pages/weekly.js
@@ -7,7 +7,7 @@ import { getWeeklyTopJokes } from '../lib/ratingsStorageDynamo'
 
 const navLinks = [
   { href: '/', label: 'Live Jokes' },
-  { href: '/top', label: 'Top Jokes' },
+  { href: '/best-dad-jokes', label: 'Top Jokes' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/about', label: 'About' },
 ]
@@ -108,7 +108,7 @@ export default function WeeklyPage({ jokes, updatedAt, error }) {
         <div className={styles.cta}>
           <p>See all-time community favorites on the Hall of Fame, or go rate more jokes.</p>
           <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', justifyContent: 'center' }}>
-            <Link href="/top" className={styles.ctaButton}>All-Time Top Jokes</Link>
+            <Link href="/best-dad-jokes" className={styles.ctaButton}>All-Time Top Jokes</Link>
             <Link href="/" className={styles.ctaButton} style={{ background: 'transparent', border: '1px solid rgba(243,156,18,0.5)', color: 'var(--color-primary)' }}>Rate Jokes</Link>
           </div>
         </div>

--- a/styles/About.module.css
+++ b/styles/About.module.css
@@ -142,6 +142,34 @@
   color: rgba(226, 232, 240, 0.6);
 }
 
+/* FAQ */
+.faqList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.faqItem {
+  background: rgba(22, 22, 22, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.faqItem h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #f7dc6f;
+}
+
+.faqItem p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: rgba(226, 232, 240, 0.75);
+}
+
 /* Links */
 .link {
   color: #f7dc6f;


### PR DESCRIPTION
- Dashboard: add Total Jokes and % Jokes Rated cards to Big Picture section
- Dashboard: fetch total joke count in getServerSideProps (runs in parallel with getDashboardStats)
- ratingsStorageDynamo: add getLowRatedJokeIds() to query GSI1 for jokes below average threshold
- random-joke API: filter out jokes with avg <= 1.5 and >= 3 ratings so poor jokes stop appearing
- About page: add FAQ section with NSFW content message and 1-star rating guidance

https://claude.ai/code/session_01HDRyTA33yYrkAA2bWVZB2w